### PR TITLE
ensure exec have file extensions so addlicense can work correctly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,12 +45,12 @@ just a few small guidelines you need to follow.
         1.  For Google-authored source files, paste the Apache header text in
             the comments at the top. (If you're using different license, include
             the full text of that license.)
-1.  Place an executable called `pipeline` on the root of your solution folder
+1.  Place an executable called `pipeline.sh` on the root of your solution folder
     which builds, deploy and tests your solution. This file will be executed by
     our automation daily. Make sure that you use an appropriate
-    [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) if you want the automation
-    to execute a text file. See
-    [this example pipeline](https://github.com/apigee/DevRel/blob/master/demos/hello-world/pipeline)
+    [shebang](https://en.wikipedia.org/wiki/Shebang_(Unix)) if you want the
+    automation to execute a text file. See [this example
+    pipeline](https://github.com/apigee/DevRel/blob/master/demos/hello-world/pipeline.sh)
     implementation.
 1.  Submit a pull request.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,4 +35,4 @@ USER devrel
 ADD --chown=devrel . /home/devrel/src
 
 WORKDIR src
-CMD ./run-pipeline
+CMD ./run-pipeline.sh

--- a/demos/hello-world/pipeline
+++ b/demos/hello-world/pipeline
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-set -e
-
-npm run deploy
-npm test
-npm run docs

--- a/demos/hello-world/pipeline.sh
+++ b/demos/hello-world/pipeline.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+npm run deploy
+npm test
+npm run docs

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "build-pipeline-runner": "docker build -t apigee/devrel .",
-    "pipeline": "docker run -e APIGEE_USER -e APIGEE_PASS -e APIGEE_ORG -e APIGEE_ENV -it apigee/devrel ./run-pipeline"
+    "pipeline": "docker run -e APIGEE_USER -e APIGEE_PASS -e APIGEE_ORG -e APIGEE_ENV -it apigee/devrel ./run-pipeline.sh"
   },
   "dependencies": {
     "eslint": "^7.0.0",

--- a/run-pipeline.sh
+++ b/run-pipeline.sh
@@ -1,5 +1,19 @@
 #!/bin/sh
 
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -e
 set -x
 
@@ -27,27 +41,27 @@ APIGEE_JS_FILES=`find $DIR -type f -wholename "*resources/jsc/*.js"`
 NODE_JS_FILES=`find . -type f -wholename "*.js" | grep -v "resources/jsc" | grep -v "node_modules"`
 [ -z "$NODE_JS_FILES" ] || npx -q eslint -c .eslintrc.yml $NODE_JS_FILES || REPORT_FAIL=$REPORT_FAIL"NODE "
 
-if test -f "$DIR/pipeline"; then
+if test -f "$DIR/pipeline.sh"; then
   # we are running under a single solution
-  (cd $DIR && ./pipeline) || REPORT_FAIL=$REPORT_FAIL$D" "
+  (cd $DIR && ./pipeline.sh) || REPORT_FAIL=$REPORT_FAIL$D" "
 else
   # we are running for the entire devrel
   for D in `ls $DIR/demos`
   do
     echo "Running pipeline on /demos/"$D
-    (cd ./demos/$D && ./pipeline) || REPORT_FAIL=$REPORT_FAIL$D" "
+    (cd ./demos/$D && ./pipeline.sh) || REPORT_FAIL=$REPORT_FAIL$D" "
   done
 
   for D in `ls $DIR/labs`
   do
     echo "Running pipeline on /labs/"$D
-    (cd ./labs/$D && ./pipeline) || REPORT_FAIL=$REPORT_FAIL$D" "
+    (cd ./labs/$D && ./pipeline.sh) || REPORT_FAIL=$REPORT_FAIL$D" "
   done
 
   for D in `ls $DIR/tools`
   do
     echo "Running pipeline on /tools/"$D
-    (cd ./tools/$D && ./pipeline) || REPORT_FAIL=$REPORT_FAIL$D" "
+    (cd ./tools/$D && ./pipeline.sh) || REPORT_FAIL=$REPORT_FAIL$D" "
   done
 fi
 


### PR DESCRIPTION
What's changed, or what was fixed?
-   added `sh` extension to the pipeline executables so addlicense can check the license headers correctly.

-   [x] I have run all the tests locally and they all pass.
-   [x] I have followed the relevant style guide for my changes.

**CC:** @apigee-devrel-reviewers
