### PR TITLE
mount generated dir to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,6 @@ RUN go get github.com/google/addlicense
 
 RUN (cd tools/java && curl -sSL https://github.com/google/google-java-format/releases/download/google-java-format-1.8/google-java-format-1.8-all-deps.jar -O)
 
-#USER devrel
-#ADD --chown=devrel . /home/devrel/src
 ADD . /home/src
 
 WORKDIR src

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,7 @@
 
 FROM debian:stable
 
-RUN useradd -ms /bin/bash devrel
-WORKDIR /home/devrel
+WORKDIR /home
 
 RUN apt-get update
 RUN apt-get install -y curl golang openjdk-11-jre git
@@ -25,14 +24,15 @@ RUN apt-get install -y nodejs
 RUN mkdir -p tools/go
 RUN mkdir -p tools/java
 
-ENV GOPATH /home/devrel/tools/go
+ENV GOPATH /home/tools/go
 RUN go get github.com/googlecodelabs/tools/claat
 RUN go get github.com/google/addlicense
 
 RUN (cd tools/java && curl -sSL https://github.com/google/google-java-format/releases/download/google-java-format-1.8/google-java-format-1.8-all-deps.jar -O)
 
-USER devrel
-ADD --chown=devrel . /home/devrel/src
+#USER devrel
+#ADD --chown=devrel . /home/devrel/src
+ADD . /home/src
 
 WORKDIR src
 CMD ./run-pipeline.sh

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   ],
   "scripts": {
     "build-pipeline-runner": "docker build -t apigee/devrel .",
-    "pipeline": "docker run -e APIGEE_USER -e APIGEE_PASS -e APIGEE_ORG -e APIGEE_ENV -it apigee/devrel ./run-pipeline.sh"
+    "pipeline": "docker run -e APIGEE_USER -e APIGEE_PASS -e APIGEE_ORG -e APIGEE_ENV -v $(pwd)/generated:/home/src/generated -it apigee/devrel ./run-pipeline.sh"
   },
   "dependencies": {
     "eslint": "^7.0.0",

--- a/run-pipeline.sh
+++ b/run-pipeline.sh
@@ -20,7 +20,6 @@ set -x
 REPORT_FAIL=
 DIR="${1:-$PWD}"
 
-rm -rf ./generated
 mkdir -p ./generated/demos
 mkdir -p ./generated/labs
 mkdir -p ./generated/tools


### PR DESCRIPTION
What's changed, or what was fixed?
-   mount ./generated into devrel container

this caused some problems with permissions. there are three generally accepted approaches:

1) set the UID and GID inside the container to match the current user at build time. this has the disadvantage that the container must be built again on every machine instead of being able to be pulled from dockerhub

2) use chmod in the container to reset the permissions
this is awkward as we are mounting the ./generated directory after docker build, so these perms will change. i don't want chmod inside ./run-pipeline.sh as that will do weird stuff when we run it locally

3) run as root in container
most people just use the default 'root' user. i am picking this solution for now, while i consider a better way of force pushing the `gh-pages` branch from inside the docker container, but that will take a few days of reading up.

i picked 3 for now.

**CC:** @apigee-devrel-reviewers
