### PR TITLE
Bump Jenkins Version to include Security Patches

### DIFF
--- a/references/cicd-jenkins/airports-cicd-v1/pom.xml
+++ b/references/cicd-jenkins/airports-cicd-v1/pom.xml
@@ -137,7 +137,7 @@ limitations under the License.
 					<basedir>${target.root.dir}</basedir>
 					<includes>
 						<include>test/integration/support/init.js</include>
-						<include>apiproxy/cicd-v1.xml</include>
+						<include>apiproxy/airports-cicd-v1.xml</include>
 						<include>apiproxy/proxies/default.xml</include>
 					</includes>
 					<replacements>

--- a/references/cicd-jenkins/jenkins/README.md
+++ b/references/cicd-jenkins/jenkins/README.md
@@ -94,7 +94,8 @@ docker run \
   -e APIGEE_USER \
   -e APIGEE_PASS \
   -e APIGEE_ORG \
-  -e GIT_BRANCH=travis \
+  -e GIT_BRANCH=nightly \
   -e AUTHOR_EMAIL="cicd@apigee.google.com" \
+  -e JENKINS_ADMIN_PASS="password" \
   -it apigee-cicd/jenkinsfile-runner
 ```

--- a/references/cicd-jenkins/jenkins/jenkins-web/Dockerfile
+++ b/references/cicd-jenkins/jenkins/jenkins-web/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM jenkins/jenkins:2.239-alpine
+FROM jenkins/jenkins:2.249.1-alpine
 
 USER root
 RUN apk update && apk add --no-cache git maven nodejs npm

--- a/references/cicd-jenkins/jenkins/plugins.txt
+++ b/references/cicd-jenkins/jenkins/plugins.txt
@@ -1,8 +1,8 @@
 cucumber-reports:5.3.0
 git:4.3.0
 htmlpublisher:1.23
-junit:latest
-matrix-project:1.16
+junit:1.34
+matrix-project:1.17
 script-security:1.74
 token-macro:2.12
 workflow-step-api:2.22

--- a/references/cicd-jenkins/pipeline.sh
+++ b/references/cicd-jenkins/pipeline.sh
@@ -30,14 +30,14 @@ docker run \
   -e APIGEE_USER \
   -e APIGEE_PASS \
   -e APIGEE_ORG \
-  -e GIT_BRANCH=travis \
+  -e GIT_BRANCH=nightly \
   -e AUTHOR_EMAIL="cicd@apigee.google.com" \
+  -e JENKINS_ADMIN_PASS=password \
   -it apigee-cicd/jenkinsfile-runner-airports
 
 npm install --no-fund
-npm run docs
 
-API_NAME=airports-cicd-travis
+API_NAME=airports-cicd-nightly
 
 echo "Undeploying Proxy $API_NAME:"
 curl -u "$APIGEE_USER:$APIGEE_PASS" -X DELETE "https://api.enterprise.apigee.com/v1/organizations/$APIGEE_ORG/environments/test/apis/$API_NAME/revisions/1/deployments"


### PR DESCRIPTION
What's changed, or what was fixed?

- Bumped Jenkins Version to latest
- Replace `travis` with `nightly` for nightly build itentifiers 

**Fixes:** #issue

- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.

**CC:** @apigee-devrel-reviewers
