### PR TITLE
Serialize Jobs

### DIFF
--- a/.github/workflows/devrel-single.yml
+++ b/.github/workflows/devrel-single.yml
@@ -22,10 +22,16 @@ env:
 jobs:
   quality-check:
     name: DevRel Workflow Checks
+    timeout-minutes: 1
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2
+
+      - name: Turnstyle
+        uses: softprops/turnstyle@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: list-changed
         id: list-changed

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
 
 Common solutions and tools developed by Apigee.
 
+blah
+
 ## References
 
 This folder contains reference solutions across a variety of Apigee products.


### PR DESCRIPTION
Given that we only deploy to one Apigee org, if multiple builds come in at the same time then they will trip over one another.

#92 goes some way to solving this by reducing the duplicate jobs, but parallel jobs can still happen.

This PR adds `turnstyle` - an action to ensure only one of each workflow is running at a time. If another workflow is running, it will wait 60 seconds for it to complete and then it will fail. It can then be manually triggered at a quieter time.

This helps reduce the bandwidth of parallel deployments as well as shorten the job queue in GitHub actions.

*NOTE* this currently doesn't limit nightly builds. we will need to merge the two workflow yamls for that, but I would like to try this out first.

- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.

**CC:** @apigee-devrel-reviewers
