### PR TITLE
Fix/hybrid quickstart usability

### DIFF
--- a/tools/hybrid-quickstart/hybrid13/README.md
+++ b/tools/hybrid-quickstart/hybrid13/README.md
@@ -30,9 +30,10 @@ automatically sets them based on the default values in steps.sh.
 
 ```bash
 export PROJECT_ID=xxx
+export AX_REGION='europe-west1' # Apigee Analytics Region 
 export REGION='europe-west1'
 export ZONE='europe-west1-b'
-export DNS_NAME=apigee.example.com
+export DNS_NAME="$PROJECT_ID.example.com"
 export CLUSTER_NAME=apigee-hybrid
 ```
 

--- a/tools/hybrid-quickstart/hybrid13/steps.sh
+++ b/tools/hybrid-quickstart/hybrid13/steps.sh
@@ -22,6 +22,8 @@ set_config_params() {
     export PROJECT_ID
     gcloud config set project "$PROJECT_ID"
 
+    export AX_REGION=${AX_REGION:='europe-west1'}
+
     export REGION=${REGION:='europe-west1'}
     gcloud config set compute/region $REGION
 
@@ -41,7 +43,7 @@ set_config_params() {
     if [[ "$OS_NAME" == "Linux" ]]; then
       echo "🐧 Using Linux binaries"
       export APIGEE_CTL='apigeectl_linux_64.tar.gz'
-      export ISTIO_ASM_CLI='istio-1.6.11-asm.1-linux.tar.gz'
+      export ISTIO_ASM_CLI='istio-1.6.11-asm.1-linux-amd64.tar.gz'
       export KPT_BINARY='kpt_linux_amd64-0.34.0.tar.gz'
     elif [[ "$OS_NAME" == "Darwin" ]]; then
       echo "🍏 Using macOS binaries"
@@ -167,7 +169,7 @@ create_apigee_org() {
         \"name\":\"$PROJECT_ID\",
         \"displayName\":\"$PROJECT_ID\",
         \"description\":\"Apigee Hybrid Org\",
-        \"analyticsRegion\":\"$REGION\",
+        \"analyticsRegion\":\"$AX_REGION\",
         \"runtimeType\":\"HYBRID\",
         \"properties\" : {
           \"property\" : [ {


### PR DESCRIPTION
What's changed, or what was fixed?

- Correct ASM Path for linux (apparently the `-amd64` suffix was added)
- Explicit Variable for AX_REGION
- Improve Readme for DNS_NAME

**Fixes:** #103

- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.

**CC:** @apigee-devrel-reviewers
