### PR TITLE
Wait for hosted target to be up before running npm test in apimocker-v1

### DIFF
--- a/references/apimocker-hostedtargets/pipeline.sh
+++ b/references/apimocker-hostedtargets/pipeline.sh
@@ -18,4 +18,11 @@ set -x
 
 npm install
 npm run deploy
+
+# wait for hosted target to be up
+until curl -o /dev/null -s -f https://"$APIGEE_ORG"-"$APIGEE_ENV".apigee.net/mock/v1/dogs; do
+    printf '.'
+    sleep 2
+done
+
 npm test

--- a/tools/pipeline-runner/Dockerfile
+++ b/tools/pipeline-runner/Dockerfile
@@ -23,7 +23,7 @@ RUN apk add --no-cache \
   maven=3.6.3-r0 \
   nodejs=12.18.4-r0 \
   npm=12.18.4-r0 \
-  openjdk11-jre-headless=11.0.8_p10-r0 \
+  openjdk11-jre-headless=11.0.9_p11-r0 \
   util-linux=2.35.2-r0
 
 RUN go get github.com/google/addlicense


### PR DESCRIPTION
Wait for hosted target to be up before running npm test in apimocker-v1

- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.

**CC:** @apigee-devrel-reviewers
