### PR TITLE
Fix/jenkins dependencies

### DIFF
--- a/references/cicd-jenkins/.dockerignore
+++ b/references/cicd-jenkins/.dockerignore
@@ -1,1 +1,2 @@
 node_modules
+target

--- a/references/cicd-jenkins/README.md
+++ b/references/cicd-jenkins/README.md
@@ -38,7 +38,7 @@ use your existing infrastructure. The `jenkins` folder contains instructions
 on how to set up a dockerized Jenkins environment with all the necessary
 tooling and plugins required.
 
-#### Option A: Configure Jenkins Docker Container
+#### Option A: Run a Jenkins Docker Container
 
 See the instructions in [./jenkins/README.md](./jenkins/README.md).
 

--- a/references/cicd-jenkins/airports-cicd-v1/Jenkinsfile
+++ b/references/cicd-jenkins/airports-cicd-v1/Jenkinsfile
@@ -38,7 +38,7 @@ pipeline {
 
         stage('Clean') {
           steps {
-            sh "mvn clean"
+            sh "mvn clean -B"
           }
         }
 
@@ -105,7 +105,7 @@ pipeline {
                   ).trim()
                 }
             }
-            sh "mvn process-resources -P${env.MAVEN_PROFILE} \
+            sh "mvn process-resources -B -P${env.MAVEN_PROFILE} \
                   -Dcommit=${env.GIT_COMMIT} \
                   -Dbranch=${env.GIT_BRANCH} \
                   -Dauthor=${AUTHOR_EMAIL} \
@@ -115,13 +115,13 @@ pipeline {
 
         stage('Package proxy bundle') {
           steps {
-            sh "mvn apigee-enterprise:configure -P${env.MAVEN_PROFILE} -Ddeployment.suffix=${env.APIGEE_DEPLOYMENT_SUFFIX}"
+            sh "mvn apigee-enterprise:configure -B -P${env.MAVEN_PROFILE} -Ddeployment.suffix=${env.APIGEE_DEPLOYMENT_SUFFIX}"
           }
         }
 
         stage('Deploy proxy bundle') {
           steps {
-            sh "mvn apigee-enterprise:deploy -P${env.MAVEN_PROFILE} -Dapigee.org=${env.APIGEE_ORG} -Dapigee.username=${APIGEE_CREDS_USR} -Dapigee.password=${APIGEE_CREDS_PSW} -Ddeployment.suffix=${env.APIGEE_DEPLOYMENT_SUFFIX}"
+            sh "mvn apigee-enterprise:deploy -B -P${env.MAVEN_PROFILE} -Dapigee.org=${env.APIGEE_ORG} -Dapigee.username=${APIGEE_CREDS_USR} -Dapigee.password=${APIGEE_CREDS_PSW} -Ddeployment.suffix=${env.APIGEE_DEPLOYMENT_SUFFIX}"
           }
         }
 

--- a/references/cicd-jenkins/jenkins/README.md
+++ b/references/cicd-jenkins/jenkins/README.md
@@ -1,7 +1,7 @@
 # Jenkins Example Setup
 
-This document explains how to set up and configure a Jenkins CI server to run
-an Apigee deployment pipeline.
+This document explains how to build and configure a Jenkins CI server container
+image to run an Apigee deployment pipeline.
 
 You can choose between two different setups:
 
@@ -17,19 +17,26 @@ instance.
 
 ### Build
 
-#### Option A: Local Build
+#### Option A: Use a pre-built image
 
 ```bash
-docker build -f jenkins-web/Dockerfile -t apigee-cicd/jenkins:latest .
+docker pull ghcr.io/danistrebel/devrel/jenkins:latest
+docker tag ghcr.io/danistrebel/devrel/jenkins:latest devrel/jenkins:latest
 ```
 
-#### Option B: Cloud Build on GCP
+#### Option B: Local Build
+
+```bash
+docker build -f jenkins-web/Dockerfile -t devrel/jenkins:latest .
+```
+
+#### Option C: Cloud Build on GCP
 
 ```bash
 PROJECT_ID=$(gcloud config get-value project)
 gcloud builds submit --config ./jenkins-web/cloudbuild.yml
 docker pull gcr.io/$PROJECT_ID/apigee-cicd/jenkins:latest
-docker tag gcr.io/$PROJECT_ID/apigee-cicd/jenkins:latest apigee-cicd/jenkins:latest
+docker tag gcr.io/$PROJECT_ID/apigee-cicd/jenkins:latest devrel/jenkins:latest
 ```
 
 ### Run the Jenkins Container
@@ -58,7 +65,7 @@ docker run \
   -e APIGEE_PASS \
   -e APIGEE_ORG \
   -e JENKINS_ADMIN_PASS \
-  apigee-cicd/jenkins:latest
+  devrel/jenkins:latest
 ```
 
 After the initialization is completed, you can login with the Jenkins web UI
@@ -71,19 +78,26 @@ Follow these instructions to build and run an ephemeral Jenkinsfile runtime.
 
 ### Build
 
-#### Option A: Local Build
+#### Option A: Use a pre-built image
 
 ```bash
-docker build -f jenkinsfile-runner/Dockerfile -t apigee-cicd/jenkinsfile-runner .
+docker pull ghcr.io/danistrebel/devrel/jenkins:latest
+docker tag ghcr.io/danistrebel/devrel/jenkins:latest devrel/jenkinsfile-runner:latest
 ```
 
-#### Option B: Cloud Build on GCP
+#### Option B: Local Build
+
+```bash
+docker build -f jenkinsfile-runner/Dockerfile -t devrel/jenkinsfile-runner:latest .
+```
+
+#### Option C: Cloud Build on GCP
 
 ```bash
 PROJECT_ID=$(gcloud config get-value project)
 gcloud builds submit --config ./jenkinsfile-runner/cloudbuild.yml
 docker pull gcr.io/$PROJECT_ID/apigee-cicd/jenkinsfile-runner:latest
-docker tag gcr.io/$PROJECT_ID/apigee-cicd/jenkinsfile-runner:latest apigee-cicd/jenkinsfile-runner:latest
+docker tag gcr.io/$PROJECT_ID/apigee-cicd/jenkinsfile-runner:latest devrel/jenkinsfile-runner:latest
 ```
 
 ### Example Run
@@ -97,5 +111,5 @@ docker run \
   -e GIT_BRANCH=nightly \
   -e AUTHOR_EMAIL="cicd@apigee.google.com" \
   -e JENKINS_ADMIN_PASS="password" \
-  -it apigee-cicd/jenkinsfile-runner
+  -it devrel/jenkinsfile-runner:latest
 ```

--- a/references/cicd-jenkins/jenkins/jenkins-web/additional-plugins.txt
+++ b/references/cicd-jenkins/jenkins/jenkins-web/additional-plugins.txt
@@ -1,3 +1,3 @@
-configuration-as-code:1.41
+configuration-as-code:1.46
 workflow-aggregator:2.6
-workflow-multibranch:2.21
+workflow-multibranch:2.22

--- a/references/cicd-jenkins/jenkins/jenkinsfile-runner/Dockerfile
+++ b/references/cicd-jenkins/jenkins/jenkinsfile-runner/Dockerfile
@@ -15,11 +15,11 @@
 FROM jenkins4eval/jenkinsfile-runner:1.0-beta-25
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN apt-get update
 RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
-RUN apt-get install -y --no-install-recommends \
-  maven \
-  nodejs \
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends \
+  maven=3.6.1* \
+  nodejs=14.* \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 WORKDIR /app/jenkins

--- a/references/cicd-jenkins/jenkins/jenkinsfile-runner/Dockerfile
+++ b/references/cicd-jenkins/jenkins/jenkinsfile-runner/Dockerfile
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM jenkins4eval/jenkinsfile-runner:1.0-beta-12
+FROM jenkins4eval/jenkinsfile-runner:1.0-beta-25
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash - 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  maven=3.6.0-1 \
-  nodejs=12.19.0-1nodesource1 \
+RUN apt-get update
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash -
+RUN apt-get install -y --no-install-recommends \
+  maven \
+  nodejs \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 WORKDIR /app/jenkins

--- a/references/cicd-jenkins/jenkins/plugins.txt
+++ b/references/cicd-jenkins/jenkins/plugins.txt
@@ -1,8 +1,8 @@
 cucumber-reports:5.3.0
 git:4.3.0
 htmlpublisher:1.23
-junit:1.34
-matrix-project:1.17
-script-security:1.74
+junit:1.47
+matrix-project:1.18
+script-security:1.75
 token-macro:2.12
-workflow-step-api:2.22
+workflow-step-api:2.23

--- a/references/cicd-jenkins/pipeline.sh
+++ b/references/cicd-jenkins/pipeline.sh
@@ -17,14 +17,17 @@
 set -e
 set -x
 
-docker build -f jenkins/jenkinsfile-runner/Dockerfile -t apigee-cicd/jenkinsfile-runner ./jenkins
+# TODO figure out how to move this to apigee/devrel repo
+# See https://github.com/apigee/devrel/issues/76
+docker pull ghcr.io/danistrebel/devrel/jenkinsfile-runner:latest
+docker tag ghcr.io/danistrebel/devrel/jenkinsfile-runner:latest devrel/jenkinsfile-runner:latest
 
 # because volume mounts don't work inside docker in docker without reference to the host file system
 cat << EOF >> /tmp/Dockerfile-jenkins-cicd
-FROM apigee-cicd/jenkinsfile-runner
+FROM devrel/jenkinsfile-runner:latest
 COPY ./airports-cicd-v1 /workspace
 EOF
-docker build -f /tmp/Dockerfile-jenkins-cicd -t apigee-cicd/jenkinsfile-runner-airports .
+docker build -f /tmp/Dockerfile-jenkins-cicd -t devrel/jenkinsfile-runner-airports:latest .
 rm /tmp/Dockerfile-jenkins-cicd
 
 docker run \
@@ -34,7 +37,7 @@ docker run \
   -e GIT_BRANCH=nightly \
   -e AUTHOR_EMAIL="cicd@apigee.google.com" \
   -e JENKINS_ADMIN_PASS=password \
-  -i apigee-cicd/jenkinsfile-runner-airports
+  -i devrel/jenkinsfile-runner-airports:latest
 
 npm install --no-fund
 


### PR DESCRIPTION
What's changed, or what was fixed?

- Fix Jenkins plugin version dependencies
- Using published container images on ghcr.io to speed up the cicd pipeline and simplify getting started
- Images should ultimately move to apigee/devrel as we figure out how to do #76

**Fixes:** #126 

- [ ] I have run all the tests locally and they all pass. (issues with pipeline locally)
- [x] I have followed the relevant style guide for my changes.

**CC:** @apigee-devrel-reviewers
