### PR TITLE
#163 Improve Nightly Builds

### DIFF
--- a/tools/pipeline-runner/cloudbuild.yaml
+++ b/tools/pipeline-runner/cloudbuild.yaml
@@ -12,9 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 steps:
-# Build the runner image
+- name: 'gcr.io/cloud-builders/gcloud'
+  id: 'Turnstyle DevRel Pipeline'
+  entrypoint: 'bash'
+  args:
+  - '-c'
+  - |
+    if [ "$(gcloud builds list --ongoing --format='value(id)' | wc  -l | xargs)" -gt "1" ]; then
+      echo "Pipeline is already running";
+      exit -1;
+    fi
 - name: 'gcr.io/cloud-builders/docker'
+  id: 'Build Image'
   args:
   - 'build'
   - '-f'
@@ -22,9 +33,8 @@ steps:
   - '-t'
   - 'gcr.io/$PROJECT_ID/devrel-pipeline:latest'
   - './tools/pipeline-runner'
-  id: 'pipeline-build'
-# Load secrets from secret manager
 - name: 'gcr.io/$PROJECT_ID/devrel-pipeline:latest'
+  id: 'Load Secrets'
   entrypoint: "sh"
   args:
     - "-c"
@@ -44,8 +54,8 @@ steps:
       echo "export GITHUB_TOKEN=\"$(gcloud secrets versions access latest \
         --secret=devrel_github_token --format="get(payload.data)" | \
         base64 -d )\"" >> env.txt
-# Run pipeline for a specific path or all projects
 - name: 'gcr.io/$PROJECT_ID/devrel-pipeline:latest'
+  id: 'Run Pipeline'
   entrypoint: "sh"
   args:
     - "-c"
@@ -59,8 +69,8 @@ steps:
   env:
   - 'APIGEE_ORG=$_APIGEE_ORG'
   - 'APIGEE_ENV=$_APIGEE_ENV'
-# Create Github PR comments or new issues
 - name: 'gcr.io/$PROJECT_ID/devrel-pipeline:latest'
+  id: 'Create GH Comment or Issue'
   entrypoint: "bash"
   args:
     - "-c"
@@ -74,8 +84,8 @@ steps:
   - 'REPO_GH_ISSUE=$_REPO_GH_ISSUE'
   - 'CREATE_GH_ISSUE=$_CREATE_GH_ISSUE'
   - 'GH_BOT_NAME=$_GH_BOT_NAME'
-# Explicitly fail build if needed
 - name: 'gcr.io/$PROJECT_ID/devrel-pipeline:latest'
+  id: 'Explicitly Fail'
   entrypoint: "bash"
   args:
     - "-c"

--- a/tools/pipeline-runner/cloudbuild.yaml
+++ b/tools/pipeline-runner/cloudbuild.yaml
@@ -70,8 +70,10 @@ steps:
   - 'BUILD_ID=$BUILD_ID'
   - 'PROJECT_ID=$PROJECT_ID'
   - 'PR_NUMBER=$_PR_NUMBER'
+  - 'SHORT_SHA=$SHORT_SHA'
   - 'REPO_GH_ISSUE=$_REPO_GH_ISSUE'
   - 'CREATE_GH_ISSUE=$_CREATE_GH_ISSUE'
+  - 'GH_BOT_NAME=$_GH_BOT_NAME'
 # Explicitly fail build if needed
 - name: 'gcr.io/$PROJECT_ID/devrel-pipeline:latest'
   entrypoint: "bash"
@@ -86,4 +88,5 @@ substitutions:
   _CI_PROJECT: "all" # all|[path]
   _CREATE_GH_ISSUE: "false" # true|false
   _REPO_GH_ISSUE: "apigee/devrel"
+  _GH_BOT_NAME: "apigee-devrel-bot"
   # _PR_NUMBER: # automatically set for PRs


### PR DESCRIPTION
What's changed, or what was fixed?

- Reuse existing issues about failing nightly builds
- Add commit hash to the report for later reference
- Implement turnstyle to only run one DevRel pipeline at the time whilst still allowing for sub-builds to be triggered
- cache maven in GCS bucket
- Fix typo in title

**Fixes:** #163 

- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.

**CC:** @apigee-devrel-reviewers
