### PR TITLE
add xmllint to pipeline runner

### DIFF
--- a/tools/pipeline-runner/Dockerfile
+++ b/tools/pipeline-runner/Dockerfile
@@ -17,6 +17,7 @@ FROM google/cloud-sdk:alpine
 # Install additional tools
 RUN apk add --no-cache \
   jq \
+  libxml2-utils \
   maven \
   nodejs \
   npm \


### PR DESCRIPTION
xmllint is a useful, and super small tool for validating xml and evaluating XPaths

it is used in the tests for #175 

- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.

**CC:** @apigee-devrel-reviewers
