### PR TITLE
more stable quick start in -e mode

### DIFF
--- a/tools/hybrid-quickstart/README.md
+++ b/tools/hybrid-quickstart/README.md
@@ -38,7 +38,7 @@ export PROJECT_ID=xxx
 export AX_REGION='europe-west1'
 # Default GCP region for runtime
 export REGION='europe-west1'
-export ZONE='europe-west1-b'
+export ZONE='europe-west1-c'
 # Name of the GKE cluster that hosts the runtime
 export GKE_CLUSTER_NAME='apigee-hybrid'
 # Machine type of the GKE cluster that hosts the runtime

--- a/tools/hybrid-quickstart/steps.sh
+++ b/tools/hybrid-quickstart/steps.sh
@@ -80,20 +80,20 @@ set_config_params() {
 token() { echo -n "$(gcloud config config-helper --force-auth-refresh | grep access_token | grep -o -E '[^ ]+$')" ; }
 
 function wait_for_ready(){
-    local expected_status=$1
+    local expected_output=$1
     local action=$2
     local message=$3
     local max_iterations=120 # 10min
     local iterations=0
-    local signal
+    local actual_out
 
     echo -e "Start: $(date)\n"
 
     while true; do
-        ((iterations++))
+        iterations="$((iterations+1))"
 
-        signal=$(eval "$action")
-        if [ "$expected_status" = "$signal" ]; then
+        actual_out=$(bash -c "$action" || echo "error code $?")
+        if [ "$expected_output" = "$actual_out" ]; then
             echo -e "\n$message"
             break
         fi
@@ -355,7 +355,7 @@ install_asm_and_certmanager() {
     --output_dir "$QUICKSTART_TOOLS"/istio-asm \
     --only_validate
 
-  mv "$QUICKSTART_TOOLS"/istio-asm/istio-*/* "$QUICKSTART_TOOLS/istio-asm/."
+  mv "$QUICKSTART_TOOLS"/istio-asm/istio-*/* "$QUICKSTART_TOOLS/istio-asm/." || echo "[WARN] cannot move directory. Exists already?"
 
   echo "🩹 Patching the ASM Config"
   mkdir -p "$QUICKSTART_TOOLS"/kpt


### PR DESCRIPTION
What's changed, or what was fixed?

- wait_for fix for -e mode
- same ZONE for readme and code

- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.

**CC:** @apigee-devrel-reviewers
