### PR TITLE
remove the need for manual edits of the pipeline.sh to deploy for a custom idp

### DIFF
--- a/references/identity-facade/README.md
+++ b/references/identity-facade/README.md
@@ -13,11 +13,10 @@ the IdP.
 
 The IdP that is used is the [OIDC Mock IdP](../oidc-mock) but you may
 use any OIDC compliant IdP. Should you use your own IdP solution, please
-modify the value of the variable `idp_discovery_document` in the
-`pipeline.sh` script. This variable MUST point to the URL of the
-discovery document of your IdP solution.
-Other values that need to be changed are values of the 2 following variables:
+privde the following environment variables to the pipeline.sh script:
 
+- `TEST_IDP_DISCOVERY_DOCUMENT`: this variable MUST point to the URL of the
+discovery document of your IdP solution.
 - `TEST_IDP_APIGEE_CLIENT_ID`: the client_id Apigee can use to connect to
  the IdP
 - `TEST_IDP_APIGEE_CLIENT_SECRET`: the client_secret Apigee can use to

--- a/references/identity-facade/README.md
+++ b/references/identity-facade/README.md
@@ -13,7 +13,7 @@ the IdP.
 
 The IdP that is used is the [OIDC Mock IdP](../oidc-mock) but you may
 use any OIDC compliant IdP. Should you use your own IdP solution, please
-privde the following environment variables to the pipeline.sh script:
+provide the following environment variables to the pipeline.sh script:
 
 - `TEST_IDP_DISCOVERY_DOCUMENT`: this variable MUST point to the URL of the
 discovery document of your IdP solution.

--- a/references/identity-facade/test/integration/features/step_definitions/init.js
+++ b/references/identity-facade/test/integration/features/step_definitions/init.js
@@ -1,19 +1,19 @@
-/**                                                                             
-  Copyright 2020 Google LLC                                                     
-                                                                                
-  Licensed under the Apache License, Version 2.0 (the "License");               
-  you may not use this file except in compliance with the License.              
-  You may obtain a copy of the License at                                       
-                                                                                
-      https://www.apache.org/licenses/LICENSE-2.0                               
-                                                                                
-  Unless required by applicable law or agreed to in writing, software           
-  distributed under the License is distributed on an "AS IS" BASIS,             
-  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.      
-  See the License for the specific language governing permissions and           
-  limitations under the License.                                                
-                                                                                
-*/ 
+/**
+  Copyright 2020 Google LLC
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+
+*/
 const apickli = require('apickli')
 const {
   Before,
@@ -24,9 +24,9 @@ const {
 const org = process.env.APIGEE_ORG
 const env = process.env.APIGEE_ENV
 const clientId = process.env.TEST_APP_CONSUMER_KEY
+const clientSecret = process.env.TEST_APP_CONSUMER_SECRET
 const spaceCharacters = '  '
-const clientSecret = 'xsecret'
-const username = 'johndoe' 
+const username = 'johndoe'
 const password = 'dummy-password'
 const basePath = '/v1/oauth20'
 


### PR DESCRIPTION
What's changed, or what was fixed?

- users can override the 3 parameters needed to deploy for a custom IDP without editing the pipeline.sh 
- minor simplification of the test config

- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.

**CC:** @apigee-devrel-reviewers
