### PR TITLE
relying only on install_asm script for istio config

### DIFF
--- a/tools/hybrid-quickstart/README.md
+++ b/tools/hybrid-quickstart/README.md
@@ -20,6 +20,12 @@ tar --version
 #installed openssl
 openssl version
 
+# installed kpt
+kpt version
+
+# installed jq
+jq --help
+
 #installed gcloud
 gcloud version
 

--- a/tools/hybrid-quickstart/cloudbuild.yaml
+++ b/tools/hybrid-quickstart/cloudbuild.yaml
@@ -20,7 +20,8 @@ steps:
   args:
     - "-c"
     - |-
-      apt-get update && apt-get install zip -y
+      apt-get update && apt-get install zip jq -y
+      gcloud components install kpt -q
       ./initialize-runtime-gke.sh
   env:
     - 'ENV_NAME=$_QUICKSTART_ENV_NAME'


### PR DESCRIPTION
What's changed, or what was fixed?

- removing `kpt` and `jq` dependencies because all config is done via install_asm
- fixing delete service account filter

- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.

**CC:** @apigee-devrel-reviewers
