### PR TITLE
Quickstart version bump to 1.4.2

### DIFF
--- a/tools/hybrid-quickstart/steps.sh
+++ b/tools/hybrid-quickstart/steps.sh
@@ -37,7 +37,7 @@ set_config_params() {
     export GKE_CLUSTER_NAME=${GKE_CLUSTER_NAME:=apigee-hybrid}
     export GKE_CLUSTER_MACHINE_TYPE=${GKE_CLUSTER_MACHINE_TYPE:=e2-standard-4}
 
-    export APIGEE_CTL_VERSION='1.4.0'
+    export APIGEE_CTL_VERSION='1.4.2'
     export KPT_VERSION='v0.34.0'
     export CERT_MANAGER_VERSION='v1.1.0'
     export ASM_VERSION='1.8'


### PR DESCRIPTION
What's changed, or what was fixed?

- Update version from 1.4.0 to 1.4.2 (skipped 1.4.1 because of incompatible create service account script)

- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.

**CC:** @apigee-devrel-reviewers
