### PR TITLE
kvm-admin-api: api security measures

### DIFF
--- a/references/kvm-admin-api/README.md
+++ b/references/kvm-admin-api/README.md
@@ -65,17 +65,25 @@ export $API_HOSTNAME=api.my-domain.com
 ## Create or Update a KVM entry
 
 ```sh
-curl -X POST -H "Content-Type: application/json" -d '{ "name": "foo", "value": "bar" }' "https://$API_HOSTNAME/kvm-admin/v1/kvms/$KVM_NAME/entries"
+curl -X POST \
+    -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $TOKEN" \
+    -d '{ "name": "foo", "value": "bar" }' \
+    "https://$API_HOSTNAME/kvm-admin/v1/organizations/$APIGEE_ORG/environments/$APIGEE_ENV/keyvaluemaps/$KVM_NAME/entries"
 ```
 
 ## Read a KVM entry
 
 ```sh
-curl -X GET "https://$API_HOSTNAME/kvm-admin/v1/kvms/$KVM_NAME/entries/foo"
+curl -X GET \
+    -H "Authorization: Bearer $TOKEN" \
+    "https://$API_HOSTNAME/kvm-admin/v1/organizations/$APIGEE_ORG/environments/$APIGEE_ENV/keyvaluemaps/$KVM_NAME/entries/foo"
 ```
 
 ## Delete a KVM entry
 
 ```sh
-curl -X DELETE "https://$API_HOSTNAME/kvm-admin/v1/kvms/$KVM_NAME/entries/foo"
+curl -X DELETE \
+    -H "Authorization: Bearer $TOKEN" \
+    "https://$API_HOSTNAME/kvm-admin/v1/organizations/$APIGEE_ORG/environments/$APIGEE_ENV/keyvaluemaps/$KVM_NAME/entries/foo"
 ```

--- a/references/kvm-admin-api/apiproxy/policies/AM-RemoveAuthzHeader.xml
+++ b/references/kvm-admin-api/apiproxy/policies/AM-RemoveAuthzHeader.xml
@@ -14,9 +14,10 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<ExtractVariables name="EV-PathParameters">
-    <URIPath>
-        <Pattern ignoreCase="true">/organizations/{kvm.orgname}/environments/{kvm.envname}/keyvaluemaps/{kvm.name}/entries/{kvm-entry.key}</Pattern>
-        <Pattern ignoreCase="true">/organizations/{kvm.orgname}/environments/{kvm.envname}/keyvaluemaps/{kvm.name}/entries</Pattern>
-    </URIPath>
-</ExtractVariables>
+<AssignMessage continueOnError="false" enabled="true" name="AM-RemoveAuthzHeader">
+    <Remove>
+        <Headers>
+            <Header name="Authorization"/>
+        </Headers>
+    </Remove>
+</AssignMessage>

--- a/references/kvm-admin-api/apiproxy/policies/AM-SetResponse.xml
+++ b/references/kvm-admin-api/apiproxy/policies/AM-SetResponse.xml
@@ -14,7 +14,6 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-
 <AssignMessage name="AM-SetResponse">
     <Set>
         <Payload contentType="application/json">{"name": "{kvm-entry.key}", "value": "{private.kvm-entry.value}"}</Payload>

--- a/references/kvm-admin-api/apiproxy/policies/RF-401.xml
+++ b/references/kvm-admin-api/apiproxy/policies/RF-401.xml
@@ -14,9 +14,13 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<ExtractVariables name="EV-PathParameters">
-    <URIPath>
-        <Pattern ignoreCase="true">/organizations/{kvm.orgname}/environments/{kvm.envname}/keyvaluemaps/{kvm.name}/entries/{kvm-entry.key}</Pattern>
-        <Pattern ignoreCase="true">/organizations/{kvm.orgname}/environments/{kvm.envname}/keyvaluemaps/{kvm.name}/entries</Pattern>
-    </URIPath>
-</ExtractVariables>
+
+<RaiseFault continueOnError="false" enabled="true" name="RF-401">
+    <FaultResponse>
+        <Set>
+            <StatusCode>401</StatusCode>
+            <ReasonPhrase>Unauthenticated</ReasonPhrase>
+            <Payload contentType="application/json">{"code": "401.99.01", "message": "Unauthenticated"}</Payload>
+        </Set>
+    </FaultResponse>
+</RaiseFault>

--- a/references/kvm-admin-api/apiproxy/policies/RF-403.xml
+++ b/references/kvm-admin-api/apiproxy/policies/RF-403.xml
@@ -14,9 +14,13 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<ExtractVariables name="EV-PathParameters">
-    <URIPath>
-        <Pattern ignoreCase="true">/organizations/{kvm.orgname}/environments/{kvm.envname}/keyvaluemaps/{kvm.name}/entries/{kvm-entry.key}</Pattern>
-        <Pattern ignoreCase="true">/organizations/{kvm.orgname}/environments/{kvm.envname}/keyvaluemaps/{kvm.name}/entries</Pattern>
-    </URIPath>
-</ExtractVariables>
+
+<RaiseFault name="RF-403">
+    <FaultResponse>
+        <Set>
+            <StatusCode>403</StatusCode>
+            <ReasonPhrase>Unauthorized</ReasonPhrase>
+            <Payload contentType="application/json">{"code": "403.99.01", "message": "Unauthorized"}</Payload>
+        </Set>
+    </FaultResponse>
+</RaiseFault>

--- a/references/kvm-admin-api/apiproxy/policies/SpikeArrest.xml
+++ b/references/kvm-admin-api/apiproxy/policies/SpikeArrest.xml
@@ -14,9 +14,9 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<ExtractVariables name="EV-PathParameters">
-    <URIPath>
-        <Pattern ignoreCase="true">/organizations/{kvm.orgname}/environments/{kvm.envname}/keyvaluemaps/{kvm.name}/entries/{kvm-entry.key}</Pattern>
-        <Pattern ignoreCase="true">/organizations/{kvm.orgname}/environments/{kvm.envname}/keyvaluemaps/{kvm.name}/entries</Pattern>
-    </URIPath>
-</ExtractVariables>
+
+<SpikeArrest continueOnError="false" enabled="true" name="SpikeArrest">
+    <DisplayName>SpikeArrest</DisplayName>
+    <Properties/>
+    <Rate>10ps</Rate>
+</SpikeArrest>

--- a/references/kvm-admin-api/apiproxy/policies/ValidateToken.xml
+++ b/references/kvm-admin-api/apiproxy/policies/ValidateToken.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+ Copyright 2021 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<ServiceCallout continueOnError="false" enabled="true" name="ValidateToken">
+    <DisplayName>ValidateToken</DisplayName>
+    <Properties/>
+    <Request clearPayload="true" variable="validateTokenRequest">
+        <Set>
+            <Headers>
+                <Header name="Authorization">{request.header.Authorization}</Header>
+            </Headers>
+            <Verb>GET</Verb>
+        </Set>
+        <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+    </Request>
+    <Response>tokenResponse</Response>
+    <HTTPTargetConnection>
+        <Properties/>
+        <URL>https://apigee.googleapis.com/v1/organizations/{kvm.orgname}/environments/{kvm.envname}/keyvaluemaps</URL>
+    </HTTPTargetConnection>
+</ServiceCallout>

--- a/references/kvm-admin-api/apiproxy/proxies/default.xml
+++ b/references/kvm-admin-api/apiproxy/proxies/default.xml
@@ -14,18 +14,42 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-
 <ProxyEndpoint name="default">
     <PreFlow name="PreFlow">
         <Request>
             <Step>
+                <Name>SpikeArrest</Name>
+            </Step>
+            <Step>
+                <Name>RF-401</Name>
+                <Condition>request.header.Authorization = null</Condition>
+            </Step>
+            <Step>
                 <Name>EV-PathParameters</Name>
+            </Step>
+            <Step>
+                <Name>RF-404</Name>
+                <Condition>kvm.orgname is null or kvm.envname is null</Condition>
+            </Step>
+            <Step>
+                <Name>RF-403</Name>
+                <Condition>kvm.orgname != organization.name or kvm.envname != environment.name</Condition>
+            </Step>
+            <Step>
+                <Name>ValidateToken</Name>
+            </Step>
+            <Step>
+                <Name>AM-RemoveAuthzHeader</Name>
+            </Step>
+            <Step>
+                <Name>RF-401</Name>
+                <Condition>servicecallout.ValidateToken.failed = true</Condition>
             </Step>
         </Request>
     </PreFlow>
     <Flows>
-        <Flow name="GET /kvms/*/entries/*">
-            <Condition>(proxy.pathsuffix MatchesPath "/kvms/*/entries/*") and  (request.verb = "GET")</Condition>
+        <Flow name="GET /keyvaluemaps/*/entries/*">
+            <Condition>(proxy.pathsuffix MatchesPath "/organizations/*/environments/*/keyvaluemaps/*/entries/*") and  (request.verb = "GET")</Condition>
             <Request>
                 <Step>
                     <Name>KV-GetEntryDynamic</Name>
@@ -41,8 +65,8 @@
                 </Step>
             </Response>
         </Flow>
-        <Flow name="POST /kvms/*/entries/*">
-            <Condition>(proxy.pathsuffix MatchesPath "/kvms/*/entries") and (request.verb = "POST")</Condition>
+        <Flow name="POST /keyvaluemaps/*/entries/*">
+            <Condition>(proxy.pathsuffix MatchesPath "/organizations/*/environments/*/keyvaluemaps/*/entries") and (request.verb = "POST")</Condition>
             <Request>
                 <Step>
                     <Name>EV-ParseRequestBody</Name>
@@ -52,8 +76,8 @@
                 </Step>
             </Request>
         </Flow>
-        <Flow name="DELETE /kvms/*/entries/*">
-            <Condition>(proxy.pathsuffix MatchesPath "/kvms/*/entries/*") and (request.verb = "DELETE")</Condition>
+        <Flow name="DELETE /keyvaluemaps/*/entries/*">
+            <Condition>(proxy.pathsuffix MatchesPath "/organizations/*/environments/*/keyvaluemaps/*/entries/*") and (request.verb = "DELETE")</Condition>
             <Request>
                 <Step>
                     <Name>KV-DeleteEntryDynamic</Name>
@@ -77,7 +101,6 @@
             </Request>
         </Flow>
     </Flows>
-
     <FaultRules>
         <FaultRule name="Missing KVM">
             <Condition>(fault.name = "MapNotFound")</Condition>
@@ -85,8 +108,7 @@
                 <Name>RF-404</Name>
             </Step>
         </FaultRule>
-     </FaultRules>
-
+    </FaultRules>
     <HTTPProxyConnection>
         <BasePath>/kvm-admin/v1</BasePath>
         <VirtualHost>secure</VirtualHost>


### PR DESCRIPTION
What's changed, or what was fixed?

1) Validate token using a ServiceCallout to apigee.googleapis.com. This ensures the user has access to the KVM.
2) Validate org and env for each call so the call is ensured to come to the right org, env that was intended.
3) Rename kvms to keyvaluemaps in the resource path to align with the mgmt API
4) Spike Arrest

**Fixes:** #issue

- [ ] I have run all the tests locally and they all pass.
- [ ] I have followed the relevant style guide for my changes.

**CC:** @apigee-devrel-reviewers
