### PR TITLE
renaming shared flow bundle file

### DIFF
--- a/references/common-shared-flows/logging-v1/sharedflowbundle/logging-v1.xml
+++ b/references/common-shared-flows/logging-v1/sharedflowbundle/logging-v1.xml
@@ -14,4 +14,4 @@ See the License for the specific language governing permissions and
 limitations under the License.                                                  
                                                                                 
 -->
-<SharedFlowBundle revision="2" name="ping-v1"/>
+<SharedFlowBundle revision="1" name="logging-v1"/>


### PR DESCRIPTION
What's changed, or what was fixed?

- renamed logging-v1 bundle file to reflect the intent.

**Fixes:** #207 thanks @davormilutinovic

- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.

**CC:** @apigee-devrel-reviewers
