### PR TITLE
Bump jenkins plugin versions

### DIFF
--- a/references/cicd-pipeline/ci-config/jenkins/Jenkinsfile
+++ b/references/cicd-pipeline/ci-config/jenkins/Jenkinsfile
@@ -90,10 +90,8 @@ pipeline {
         stage('Env Config') {
           steps {
             script {
-              if (env.AUTHOR_EMAIL) {
-                AUTHOR_EMAIL = env.AUTHOR_EMAIL
-              } else {
-                AUTHOR_EMAIL = sh (
+              if (!env.AUTHOR_EMAIL) {
+                env.AUTHOR_EMAIL = sh (
                   script: 'git --no-pager show -s --format=\'%ae\'',
                   returnStdout: true
                 ).trim()

--- a/references/cicd-pipeline/jenkins-build/jenkins-web/Dockerfile
+++ b/references/cicd-pipeline/jenkins-build/jenkins-web/Dockerfile
@@ -15,7 +15,7 @@
 FROM jenkins/jenkins:2.249.1-alpine
 
 USER root
-RUN apk update && apk add --no-cache git=2.26.2-r0 maven=3.6.3-r0 nodejs=12.18.4-r0 npm=12.18.4-r0
+RUN apk update && apk add --no-cache git maven nodejs npm
 USER jenkins
 
 COPY --chown=jenkins plugins.txt /usr/share/jenkins/ref/plugins.txt

--- a/references/cicd-pipeline/jenkins-build/jenkins-web/additional-plugins.txt
+++ b/references/cicd-pipeline/jenkins-build/jenkins-web/additional-plugins.txt
@@ -1,3 +1,3 @@
-configuration-as-code:1.46
+configuration-as-code:1.47
 workflow-aggregator:2.6
 workflow-multibranch:2.22

--- a/references/cicd-pipeline/jenkins-build/plugins.txt
+++ b/references/cicd-pipeline/jenkins-build/plugins.txt
@@ -3,6 +3,6 @@ git:4.3.0
 htmlpublisher:1.23
 junit:1.47
 matrix-project:1.18
-script-security:1.75
+script-security:1.76
 token-macro:2.12
 workflow-step-api:2.23


### PR DESCRIPTION
What's changed, or what was fixed?

- Bump several jenkins plugin versions
- Remove hardcoded versions from alpine packages (as we do in the pipeline runner)

**Fixes:** #219

- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.

**CC:** @apigee-devrel-reviewers
