### PR TITLE
Using nip.io as the default hostname for hybrid quickstart

### DIFF
--- a/tools/hybrid-quickstart/README.md
+++ b/tools/hybrid-quickstart/README.md
@@ -46,9 +46,9 @@ export GKE_CLUSTER_MACHINE_TYPE='e2-standard-4'
 # Apigee Config
 export ENV_NAME='test1'
 export ENV_GROUP_NAME='test'
-# Subdomain will be created for every environment group
-# e.g. test.$PROJECT_ID.example.com
-export DNS_NAME="$PROJECT_ID.example.com"
+# A subdomain will be created for every environment group
+# e.g. test.1-2-3-4.nip.io (where 1.2.3.4 is the IP of the isto ingress)
+export DNS_NAME="my-ingress-ip.nip.io" # where `my-ingress-ip` is determined at runtime
 # Choose between 'external' and 'internal' ingress
 export INGRESS_TYPE="external"
 ```

--- a/tools/hybrid-quickstart/README.md
+++ b/tools/hybrid-quickstart/README.md
@@ -8,7 +8,16 @@ initial end to end setup without production grade hardening and reliability.
 For tooling related to production setup and operation of Apigee hybrid, please
 visit the [AHR project on Github](https://github.com/apigee/ahr).
 
+This script is tested on MacOS and Linux with the prerequisites in the next
+section installed. It can also be run in Cloud Shell. In case your cloud shell
+times out just run it again.
+
+[![Open in Cloud Shell](https://gstatic.com/cloudssh/images/open-btn.svg)](https://ssh.cloud.google.com/cloudshell/editor?cloudshell_git_repo=https://github.com/apigee/devrel&cloudshell_workspace=tools/hybrid-quickstart&cloudshell_tutorial=README.md)
+
 ## Prerequisites
+
+In order to run the script you will need a few basic utilities and an
+initialized gcloud context:
 
 ```bash
 #installed kubectl
@@ -24,7 +33,22 @@ openssl version
 gcloud version
 
 #login if needed
-gcloud init
+gcloud auth list
+```
+
+## Select a GCP project
+
+Select the GCP project to install hybrid:
+
+```sh
+export PROJECT_ID=xxx
+```
+
+or create a new project:
+
+```sh
+gcloud projects create PROJECT_NAME [OPTIONS]
+export PROJECT_ID=PROJECT_NAME
 ```
 
 ## Override Default Config (if desired)
@@ -32,23 +56,42 @@ gcloud init
 The following environment variables are set by default.
 Export them to override the default values if neeed.
 
-```bash
-export PROJECT_ID=xxx
-# Apigee analytics region see Apigee docs for full list
+### Apigee analytics region see Apigee docs for full list
+
+```sh
 export AX_REGION='europe-west1'
-# Default GCP region for runtime
+```
+
+### GCP region and zone for the runtime
+
+```sh
 export REGION='europe-west1'
 export ZONE='europe-west1-c'
-# Name of the GKE cluster that hosts the runtime
+```
+
+### Runtime GKE cluster
+
+```sh
 export GKE_CLUSTER_NAME='apigee-hybrid'
-# Machine type of the GKE cluster that hosts the runtime
 export GKE_CLUSTER_MACHINE_TYPE='e2-standard-4'
-# Apigee Config
+```
+
+### Apigee Env Config
+
+```sh
 export ENV_NAME='test1'
 export ENV_GROUP_NAME='test'
-# A subdomain will be created for every environment group
-# e.g. test.1-2-3-4.nip.io (where 1.2.3.4 is the IP of the isto ingress)
-export DNS_NAME="my-ingress-ip.nip.io" # where `my-ingress-ip` is determined at runtime
+```
+
+### Ingress config
+
+By default a subdomain will be created for every environment group
+e.g. test.1-2-3-4.nip.io (where 1.2.3.4 is the IP of the isto ingress)
+
+`INGRESS_TYPE` can be `external` (default) or `internal`
+
+```sh
+export DNS_NAME="my-ingress-ip.nip.io"
 # Choose between 'external' and 'internal' ingress
 export INGRESS_TYPE="external"
 ```
@@ -62,7 +105,11 @@ If you use the default `DNS_NAME` you don't have to manually create a dns zone.
 
 ## Initialize the Apigee hybrid runtime on a GKE cluster
 
-```bash
+After the configuration is done run the following command to initialize you
+Apigee hybrid organization and runtime. This typically takes between 15 and
+20min.
+
+```sh
 ./initialize-runtime-gke.sh
 ```
 
@@ -73,8 +120,9 @@ See the [this](https://community.apigee.com/articles/86322/free-trusted-ssl-cert
 
 ## Clean up
 
-Delete the runtime resources to avoid paying for unused GKE clusters.
+Delete the runtime resources (without deleting the Apigee Organization) to avoid
+paying for unused GKE clusters.
 
-```bash
+```sh
 ./destroy-runtime-gke.sh
 ```

--- a/tools/hybrid-quickstart/cloudbuild.yaml
+++ b/tools/hybrid-quickstart/cloudbuild.yaml
@@ -36,7 +36,7 @@ steps:
       INGRESS_IP="$$(gcloud compute addresses list --format json \
         --filter "name=apigee-ingress-ip" --format="get(address)")"
 
-      TEST_HOST="$_QUICKSTART_ENV_GROUP_NAME.$PROJECT_ID.example.com"
+      TEST_HOST="$_QUICKSTART_ENV_GROUP_NAME.$(echo "$$INGRESS_IP" | tr '.' '-').nip.io"
 
       echo "testing proxy depoyment: curl -f -k --resolve $$TEST_HOST:443:$$INGRESS_IP
         https://$$TEST_HOST/httpbin/v0/anything"


### PR DESCRIPTION
What's changed, or what was fixed?

- Use nip service per default for the envgroup hostname. This makes the test curls easier as there is no --resolve required and is more consistent with the X provisioning script.
- Small fix for the distributed trace API

- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.

**CC:** @apigee-devrel-reviewers
