### PR TITLE
set ecmaVersion for the entire project

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -18,14 +18,14 @@ env:
 extends:
   - google
   - prettier
+parserOptions:
+  ecmaVersion: 8
 overrides:
   - files:
       [
         "references/identity-facade/test/integration/features/step_definitions/*.js",
         "references/oidc-mock/test/integration/features/step_definitions/*.js",
       ]
-    parserOptions:
-      ecmaVersion: 8
     rules:
       new-cap: 0
   - files: "**/resources/jsc/*.js"


### PR DESCRIPTION
What's changed, or what was fixed?

- set ecmaVersion to 8 for all of devrel


- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.

**CC:** @apigee-devrel-reviewers
