### PR TITLE
better KVM admin proxy debug in Sackmesser

### DIFF
--- a/tools/apigee-sackmesser/cmd/deploy/deploy.sh
+++ b/tools/apigee-sackmesser/cmd/deploy/deploy.sh
@@ -160,7 +160,7 @@ if [ -f "$temp_folder"/edge.json ]; then
                 curl -s -X POST -k --fail "https://$hostname/kvm-admin/v1/organizations/$organization/environments/$environment/keyvaluemaps/$kvmname/entries" \
                     -H "Authorization: Bearer $token" \
                     -H "Content-Type: application/json" \
-                    --data "$kvmentry" > /dev/null
+                    --data "$kvmentry" > /dev/null || ( echo "[FATAL] failed to add entry to KVM: https://$hostname/kvm-admin/v1/organizations/$organization/environments/$environment/keyvaluemaps/$kvmname" && exit 1 )
             done
         done
     fi


### PR DESCRIPTION
What's changed, or what was fixed?

- more explicit logging if Sackmesser fails to add KVM entries

**Helps diagnose:** #267

- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.

**CC:** @apigee-devrel-reviewers
