### PR TITLE
document Admin API usage in README

### DIFF
--- a/references/kvm-admin-api/README.md
+++ b/references/kvm-admin-api/README.md
@@ -5,24 +5,26 @@ accessing and modifying the entries of Apigee Key Value Maps (KVMs). In Apigee
 hybrid and Apigee X the access to entries of the KVMs is not provided via the
 Apigee APIs and you will need to leverage Apigee policies to perform CRUD
 operations on the KVM contents.
+
 For more background information, please see [this](https://community.apigee.com/articles/89782/providing-kvm-content-apis-for-apigee-x-and-hybrid.html)
 article in the Apigee community.
 
 This project provides a reference implementation for how to read, write and
-delete entries within environment scoped KVMs inside Apigee regardless of the
-deployment model and the existence of KVM management APIs.
+delete entries within environment scoped KVMs in Apigee X or hybrid.
 
-**Note:** This reference implementation leverages cloud based Apigee API
+**Note:** For simplicity his reference implementation leverages cloud based
+Apigee API
 [organizations.environments.testIamPermissions](https://cloud.google.com/apigee/docs/reference/apis/apigee/rest/v1/organizations.environments/testIamPermissions)
-for authorization. The GET, POST, DELETE operations of this API correspond
-to list, create and delete IAM permissions on keyvaluemaps. The proxy needs
-access to apigee.googleapis.com to work correctly.
+for authorization. The GET, POST, DELETE operations of this API correspond to
+list, create and delete IAM permissions on keyvaluemaps. The proxy needs access
+to `apigee.googleapis.com` to work correctly. Calling the Apigee Managment APIs
+is generally considered an anti-pattern and can lead to
+[quota](https://console.cloud.google.com/iam-admin/quotas) exhaustion we
+therefore suggest to review if this is a suitable tradeoff or swap the
+existing authentication mechanism on the KVM admin proxy with a authentication
+of your choice.
 
 ## (Prerequisite) Create a KVM
-
-**Note:** Apigee SaaS currently does not allow for dynamic KVM names via the
-MapName element. It will automatically default to a KVM called `kvmap` and
-ignore the provided map name in the path.
 
 ```sh
 export TOKEN=$(gcloud auth print-access-token)
@@ -39,28 +41,16 @@ curl -X POST \
 
 ## Create the Proxy
 
-### Google APIs (Apigee hybrid and Apigee X)
-
 ```sh
 mvn clean install -ntp -B -Pgoogleapi -Dtoken=$(gcloud auth print-access-token) \
   -Dorg=$APIGEE_ORG -Dapigee.env=$APIGEE_ENV
 ```
 
-### Apigee APIs (Apigee Public Cloud)
-
-```sh
-mvn clean install -ntp -B -Papigeeapi -Dorg=$APIGEE_ORG -Denv=$APIGEE_ENV \
-  -Dusername=$APIGEE_USER -Dpassword=$APIGEE_PASS
-```
-
 ## Use the KVM Proxy
 
-First, set the hostname for your API (i.e. the `virtualhost` for your Apigee
-public cloud or your hostname for your env group in Apigee hybrid.)
+First, set the hostname that is used to reach your KVM admin proxy:
 
 ```sh
-export $API_HOSTNAME=$APIGEE_ORG-$APIGEE_ENV.apigee.net
-# or
 export $API_HOSTNAME=api.my-domain.com
 ```
 

--- a/references/kvm-admin-api/apiproxy/policies/SA-Incoming.xml
+++ b/references/kvm-admin-api/apiproxy/policies/SA-Incoming.xml
@@ -14,6 +14,6 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
-<SpikeArrest name="SpikeArrest">
+<SpikeArrest name="SA-Incoming">
     <Rate>10ps</Rate>
 </SpikeArrest>

--- a/references/kvm-admin-api/apiproxy/proxies/default.xml
+++ b/references/kvm-admin-api/apiproxy/proxies/default.xml
@@ -18,7 +18,7 @@
     <PreFlow name="PreFlow">
         <Request>
             <Step>
-                <Name>SpikeArrest</Name>
+                <Name>SA-Incoming</Name>
             </Step>
             <Step>
                 <Name>RF-401</Name>


### PR DESCRIPTION
What's changed, or what was fixed?

- Document the usage of Apigee APIs for Authentication in KVM Proxy
- Consistent Policy naming schema


- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.

**CC:** @apigee-devrel-reviewers
