### PR TITLE
 udpate docs and skip pipeline runs for markdown edits only

### DIFF
--- a/PIPELINES.md
+++ b/PIPELINES.md
@@ -39,10 +39,12 @@ The pipeline context also has the `gcloud` context of a serviceaccount user
 ## Static Checks
 
 Static code checks such as [Super Linter](https://github.com/github/super-linter)
- and [In Solidarity](https://github.com/apps/in-solidarity) are triggered
- automatically and do not need to be included in your pipeline script. We
- recommend you allow these to run in GitHub as it is simpler than running
- locally. We don't mind if the Pull Request fails at first due to these checks!
+ and [In Solidarity](https://github.com/apps/in-solidarity) are part of the
+ linter workflow. They do not need to be included in your pipeline script. We
+ recommend you allow the DevRel [workflows](.github/workflows) to automatically
+ run on your fork as this is simpler than running locally. In case the workflows
+ are disabled, you can manually enable them again as described [here](https://docs.github.com/en/actions/managing-workflow-runs/disabling-and-enabling-a-workflow).
+ We don't mind if the Pull Request fails at first due to these checks!
 
 ## GitHub Pages
 

--- a/tools/pipeline-runner/list-repo-changes.sh
+++ b/tools/pipeline-runner/list-repo-changes.sh
@@ -16,5 +16,6 @@
 git fetch origin
 
 git diff --name-only origin/main | \
+    grep -v '\.md$' | \
     grep "labs/\|references/\|tools/" | \
     awk -F '/' '{ print $1 "/" $2}' | uniq | paste -sd , -


### PR DESCRIPTION
What's changed, or what was fixed?

- Update docs to explain how to enable workflows on forks
- Skip pipeline run for markdown edits 

**Fixes:** #292

- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.

**CC:** @apigee-devrel-reviewers
