### PR TITLE
non-interactive gcloud for x-trial provisioning

### DIFF
--- a/tools/apigee-x-trial-provision/apigee-x-trial-provision.sh
+++ b/tools/apigee-x-trial-provision/apigee-x-trial-provision.sh
@@ -174,13 +174,13 @@ if [ ! "$QUIET" = "Y" ]; then
 fi
 
 echo "Step 2: Enable APIs"
-gcloud services enable apigee.googleapis.com compute.googleapis.com cloudresourcemanager.googleapis.com servicenetworking.googleapis.com cloudkms.googleapis.com --project="$PROJECT"
+gcloud services enable apigee.googleapis.com compute.googleapis.com cloudresourcemanager.googleapis.com servicenetworking.googleapis.com cloudkms.googleapis.com --project="$PROJECT" --quiet
 
 echo "Step 4: Configure service networking"
 
 if [[ "$NETWORK" =~ ^projects/.*/networks.*$ ]]; then
   set +e
-  gcloud compute networks describe "$NETWORK" --project "$PROJECT" | grep -q "$SUBNET"
+  gcloud compute networks describe "$NETWORK" --project "$PROJECT" --quiet | grep -q "$SUBNET"
   SUBNET_FOUND=$?
   set -e
   if [ "$SUBNET_FOUND" = "0" ]; then
@@ -194,25 +194,25 @@ else
   if [ -z "$PEERING_CIDR" ]; then
     gcloud compute addresses create google-managed-services-default --global --prefix-length=23 \
       --description="Peering range for Google Apigee X Tenant" --network="$NETWORK" \
-      --purpose=VPC_PEERING --project="$PROJECT" || echo "Failed to create - ignoring assuming it already exists"
+      --purpose=VPC_PEERING --project="$PROJECT" --quiet || echo "Failed to create - ignoring assuming it already exists"
   else
     RANGE_START="$(echo "$PEERING_CIDR" | cut -d/ -f1)"
     RANGE_PREFIX_LENGTH="$(echo "$PEERING_CIDR" | cut -d/ -f2)"
     gcloud compute addresses create google-managed-services-default --global  --addresses="$RANGE_START" --prefix-length="$RANGE_PREFIX_LENGTH" \
       --description="Peering range for Google Apigee X Tenant" --network="$NETWORK" \
-      --purpose=VPC_PEERING --project="$PROJECT" || echo "Failed to create - ignoring assuming it already exists"
+      --purpose=VPC_PEERING --project="$PROJECT" --quiet || echo "Failed to create - ignoring assuming it already exists"
   fi
 
   echo "Step 4.2: Connect your project's network to the Service Networking API via VPC peering"
   gcloud services vpc-peerings connect --service=servicenetworking.googleapis.com \
-    --network="$NETWORK" --ranges=google-managed-services-default --project="$PROJECT" ||
+    --network="$NETWORK" --ranges=google-managed-services-default --project="$PROJECT"  --quiet ||
     echo "Failed to create - ignoring assuming it already exists"
 
   echo "Step 7d.3: Create a firewall rule that lets the Load Balancer access Proxy VM"
   gcloud compute firewall-rules create k8s-allow-lb-to-apigee-proxy \
     --description "Allow incoming from GLB on TCP port 443 to Apigee Proxy" --network "$NETWORK" \
     --allow=tcp:443 --source-ranges=130.211.0.0/22,35.191.0.0/16 --target-tags=gke-apigee-proxy \
-    --project "$PROJECT" || echo "Failed to create - ignoring assuming it already exists"
+    --project "$PROJECT" --quiet || echo "Failed to create - ignoring assuming it already exists"
 fi
 
 if [ "$SHARED_HOST_ONLY" = "Y" ]; then
@@ -229,7 +229,7 @@ fi
 export MIG=apigee-proxy-$REGION
 
 echo "Validation: valid region value: $REGION"
-CHECK_REGION=$(gcloud compute regions list --filter="name=( \"$REGION\" )" --format="table[no-heading](name)" --project="$PROJECT")
+CHECK_REGION=$(gcloud compute regions list --filter="name=( \"$REGION\" )" --format="table[no-heading](name)" --project="$PROJECT" --quiet)
 if [ "$REGION" != "$CHECK_REGION" ]; then
   echo "ERROR: region value is invalid: $REGION"
   exit
@@ -239,7 +239,7 @@ if [ "$APIGEE_PROVISIONED" = "T" ]; then
 
   echo "Apigee Organization is already provisioned."
   echo "Reserved IP addresses for network $NETWORK:"
-  gcloud compute addresses list --project "$PROJECT"
+  gcloud compute addresses list --project "$PROJECT" --quiet
 
   echo ""
   echo "Skipping Service networking and Organization Provisioning steps."
@@ -249,11 +249,12 @@ else
 echo "Step 4.4: Create a new eval org [it takes time, 10-20 minutes. please wait...]"
 
 set +e
+gcloud components install alpha --quiet # as the cloud-sdk image no longer has this
 gcloud alpha apigee organizations provision \
   --runtime-location="$REGION" \
   --analytics-region="$AX_REGION" \
   --authorized-network="$NETWORK" \
-  --project="$PROJECT"
+  --project="$PROJECT" --quiet
 set -e
 
 
@@ -269,7 +270,7 @@ echo "Step 7a: Enable Private Google Access"
 echo "# enable Private Google Access"
 gcloud compute networks subnets update "$SUBNET" \
 --region="$REGION" \
---enable-private-ip-google-access --project "$PROJECT"
+--enable-private-ip-google-access --project "$PROJECT" --quiet
 
 echo "Step 7b: Set up environment variables"
 APIGEE_ENDPOINT=$(curl --silent -H "Authorization: Bearer $(token)"  -X GET -H "Content-Type:application/json" https://apigee.googleapis.com/v1/organizations/"$ORG"/instances | jq --raw-output '.instances[0].host')
@@ -300,31 +301,31 @@ gcloud compute instance-templates create "$MIG" \
   --machine-type "$PROXY_MACHINE_TYPE""$PREEMPTIBLE_FLAG" \
   --image-family centos-7 \
   --image-project centos-cloud --boot-disk-size 20GB \
-  --metadata ENDPOINT="$APIGEE_ENDPOINT",startup-script-url=gs://apigee-5g-saas/apigee-envoy-proxy-release/latest/conf/startup-script.sh --project "$PROJECT"
+  --metadata ENDPOINT="$APIGEE_ENDPOINT",startup-script-url=gs://apigee-5g-saas/apigee-envoy-proxy-release/latest/conf/startup-script.sh --project "$PROJECT" --quiet
 
 echo "Step 7c.2: Create a managed instance group"
 gcloud compute instance-groups managed create "$MIG" \
   --base-instance-name apigee-proxy \
-  --size "$PROXY_MIG_MIN_SIZE" --template "$MIG" --region "$REGION" --project "$PROJECT"
+  --size "$PROXY_MIG_MIN_SIZE" --template "$MIG" --region "$REGION" --project "$PROJECT" --quiet
 
 echo "Step 7c.3: Configure autoscaling for the group"
 gcloud compute instance-groups managed set-autoscaling "$MIG" \
   --region "$REGION" --max-num-replicas 20 \
-  --target-cpu-utilization 0.75 --cool-down-period 90 --project "$PROJECT"
+  --target-cpu-utilization 0.75 --cool-down-period 90 --project "$PROJECT" --quiet
 
 echo "Step 7c.4: Defined a named port"
 
 gcloud compute instance-groups managed set-named-ports "$MIG" \
-  --region "$REGION" --named-ports https:443 --project "$PROJECT"
+  --region "$REGION" --named-ports https:443 --project "$PROJECT" --quiet
 
 echo "Step 7d: Create firewall rules"
 
 
 echo "Step 7d.1: Reserve an IP address for the Load Balancer"
-gcloud compute addresses create lb-ipv4-vip-1 --ip-version=IPV4 --global --project "$PROJECT"
+gcloud compute addresses create lb-ipv4-vip-1 --ip-version=IPV4 --global --project "$PROJECT" --quiet
 
 echo "Step 7d.2: Get a reserved IP address"
-RUNTIME_IP=$(gcloud compute addresses describe lb-ipv4-vip-1 --format="get(address)" --global --project "$PROJECT")
+RUNTIME_IP=$(gcloud compute addresses describe lb-ipv4-vip-1 --format="get(address)" --global --project "$PROJECT" --quiet)
 export RUNTIME_IP
 
 
@@ -335,7 +336,7 @@ if [ "$CERTIFICATES" = "managed" ]; then
   echo "Step 7e.1: Using Google managed certificate:"
   RUNTIME_HOST_ALIAS="$ENV_GROUP_NAME".$(echo "$RUNTIME_IP" | tr '.' '-').nip.io
   gcloud compute ssl-certificates create apigee-ssl-cert \
-    --domains="$RUNTIME_HOST_ALIAS" --project "$PROJECT"
+    --domains="$RUNTIME_HOST_ALIAS" --project "$PROJECT" --quiet
 elif [ "$CERTIFICATES" = "generated" ]; then
   echo "Step 7e.1: Generate eval certificate and key"
   export RUNTIME_TLS_CERT=~/mig-cert.pem
@@ -345,12 +346,12 @@ elif [ "$CERTIFICATES" = "generated" ]; then
   echo "Step 7e.2: Upload your TLS server certificate and key to GCP"
   gcloud compute ssl-certificates create apigee-ssl-cert \
     --certificate="$RUNTIME_TLS_CERT" \
-    --private-key="$RUNTIME_TLS_KEY" --project "$PROJECT"
+    --private-key="$RUNTIME_TLS_KEY" --project "$PROJECT" --quiet
 else
   echo "Step 7e.2: Upload your TLS server certificate and key to GCP"
   gcloud compute ssl-certificates create apigee-ssl-cert \
     --certificate="$RUNTIME_TLS_CERT" \
-    --private-key="$RUNTIME_TLS_KEY" --project "$PROJECT"
+    --private-key="$RUNTIME_TLS_KEY" --project "$PROJECT" --quiet
 fi
 
 CURRENT_HOST_ALIAS=$(curl -X GET --silent -H "Authorization: Bearer $(token)"  \
@@ -368,33 +369,33 @@ echo "Step 7f: Create a global Load Balancer"
 echo "Step 7f.1: Create a health check"
 gcloud compute health-checks create https hc-apigee-proxy-443 \
   --port 443 --global \
-  --request-path /healthz/ingress --project "$PROJECT"
+  --request-path /healthz/ingress --project "$PROJECT" --quiet
 
 echo "Step 7f.2: Create a backend service called 'apigee-proxy-backend'"
 
 gcloud compute backend-services create apigee-proxy-backend \
   --protocol HTTPS --health-checks hc-apigee-proxy-443 \
-  --port-name https --timeout 60s --connection-draining-timeout 300s --global --project "$PROJECT"
+  --port-name https --timeout 60s --connection-draining-timeout 300s --global --project "$PROJECT" --quiet
 
 echo "Step 7f.3: Add the Load Balancer Proxy VM instance group to your backend service"
 gcloud compute backend-services add-backend apigee-proxy-backend \
   --instance-group "$MIG" \
   --instance-group-region "$REGION" \
-  --balancing-mode UTILIZATION --max-utilization 0.8 --global --project "$PROJECT"
+  --balancing-mode UTILIZATION --max-utilization 0.8 --global --project "$PROJECT" --quiet
 
 echo "Step 7f.4: Create a Load Balancing URL map"
 gcloud compute url-maps create apigee-proxy-map \
-  --default-service apigee-proxy-backend --project "$PROJECT"
+  --default-service apigee-proxy-backend --project "$PROJECT" --quiet
 
 echo "Step 7f.5: Create a Load Balancing target HTTPS proxy"
 gcloud compute target-https-proxies create apigee-proxy-https-proxy \
   --url-map apigee-proxy-map \
-  --ssl-certificates apigee-ssl-cert --project "$PROJECT"
+  --ssl-certificates apigee-ssl-cert --project "$PROJECT" --quiet
 
 echo "Step 7f.6: Create a global forwarding rule"
 gcloud compute forwarding-rules create apigee-proxy-https-lb-rule \
   --address lb-ipv4-vip-1 --global \
-  --target-https-proxy apigee-proxy-https-proxy --ports 443 --project "$PROJECT"
+  --target-https-proxy apigee-proxy-https-proxy --ports 443 --project "$PROJECT" --quiet
 
 set -e
 
@@ -406,11 +407,11 @@ echo ""
 
 while true
 do
-  TLS_STATUS="$(gcloud compute ssl-certificates list --format=json  --project "$PROJECT" | jq -r '.[0].type')"
+  TLS_STATUS="$(gcloud compute ssl-certificates list --format=json  --project "$PROJECT" --quiet | jq -r '.[0].type')"
   if [ "$TLS_STATUS" = "MANAGED" ]; then
-    TLS_STATUS="$TLS_STATUS ($(gcloud compute ssl-certificates list --format=json --project "$PROJECT" | jq -r '.[0].managed.status'))"
+    TLS_STATUS="$TLS_STATUS ($(gcloud compute ssl-certificates list --format=json --project "$PROJECT" --quiet | jq -r '.[0].managed.status'))"
   fi
-  DEPLOYMENT_STATUS="$(gcloud alpha apigee deployments describe 2>/dev/null --api hello-world --environment eval --format=json | jq -r '.state')"
+  DEPLOYMENT_STATUS="$(gcloud alpha apigee deployments describe 2>/dev/null --api hello-world --environment eval --format=json --project "$PROJECT" --quiet | jq -r '.state')"
   CURL_STATUS=$(curl -k -o /dev/null -s -w "%{http_code}\n" "https://$RUNTIME_HOST_ALIAS/hello-world" --resolve "$RUNTIME_HOST_ALIAS:443:$RUNTIME_IP" || true)
   echo "Test Curl Status: $CURL_STATUS, Deployment Status: $DEPLOYMENT_STATUS, Cert Status: $TLS_STATUS"
   if [ "$CURL_STATUS" = "200" ]; then


### PR DESCRIPTION
What's changed, or what was fixed?

- add non-interactive flag (`--quiet`) to all gcloud commands in the x-trial-provisining script

**Fixes:** #304 (Nightly)

- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.

**CC:** @apigee-devrel-reviewers
