### PR TITLE
remove output prefix from pipeline output

### DIFF
--- a/tools/pipeline-runner/cloudbuild.yaml
+++ b/tools/pipeline-runner/cloudbuild.yaml
@@ -60,8 +60,12 @@ steps:
       source env.txt && \
       if [ -n "$_PR_NUMBER" ]; then
         PROJECTS=$(list-repo-changes.sh)
-        echo "PR includes changes in $$PROJECTS"
-        timeout "$$max_duration" run-pipelines.sh "$$PROJECTS" || true
+        if [ -z "$$PROJECTS" ]; then
+          echo "TOTAL PIPELINE (no change);pass;0" > ./pipeline-result.txt
+        else
+          echo "PR includes changes in $$PROJECTS"
+          timeout "$$max_duration" run-pipelines.sh "$$PROJECTS" || true
+        fi
       elif [ "$_CI_PROJECT" = "all" ]; then
         timeout "$$max_duration" run-pipelines.sh || true
       else

--- a/tools/pipeline-runner/run-pipelines.sh
+++ b/tools/pipeline-runner/run-pipelines.sh
@@ -28,7 +28,7 @@ append_pipeline_result() {
 run_single_pipeline() {
   DIR=$1
   STARTTIME=$(date +%s)
-  (cd "$DIR" && ./pipeline.sh 2>&1 | sed "s#^#[$DIR] #")
+  (cd "$DIR" && ./pipeline.sh)
   PIPELINE_EXIT=$?
   ENDTIME=$(date +%s)
   append_pipeline_result "$DIR,$PIPELINE_EXIT,$((ENDTIME-STARTTIME))s"


### PR DESCRIPTION
What's changed, or what was fixed?

- Remove pipeline output sed prefix as it masks the return type.
  - We'll need to reconsider the posix/bash for this as pipefail would be a nice option to allow for both.
- Skip pipeline if all PR changes were filtered out

**Fixes:** #issue

- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.

**CC:** @apigee-devrel-reviewers
