### PR TITLE
Peering CIDR prefix length is now /22

### DIFF
--- a/tools/apigee-x-trial-provision/README.md
+++ b/tools/apigee-x-trial-provision/README.md
@@ -146,7 +146,7 @@ When working with custom networks, the first step we do is to plan a layout of y
 | Network CIDR | 10.0.0.0/14 For routes and firewall rules, etc |
 |Subnet | exco-vpc-dev-subnet |
 | Subnet Primary Range | CIDR: 10.0.0.0/16 CIDR IP Range: 10.0.0.0 - 10.0.255.255, 65,536 IP addresses |
-| Apigee X Peering Range | /23 -- a default peering range for [Apigee X Trial installation](https://cloud.google.com/apigee/docs/api-platform/get-started/install-cli-eval) |
+| Apigee X Peering Range | /22 -- a default peering range for [Apigee X Trial installation](https://cloud.google.com/apigee/docs/api-platform/get-started/install-cli-eval) |
 
 For details on peering range, see: [Understanding of Peering Ranges](https://cloud.google.com/apigee/docs/api-platform/system-administration/peering-ranges)
 
@@ -232,7 +232,7 @@ gcloud compute instances create bastion \
     export NETWORK_CIDR=10.0.0.0/14
     export SUBNET_CIDR=10.0.0.0/16
 
-    export PEERING_CIDR=10.111.0.0/23
+    export PEERING_CIDR=10.111.0.0/22
     ```
 
 1. GCP: Create a VPC Network

--- a/tools/apigee-x-trial-provision/apigee-x-trial-provision.sh
+++ b/tools/apigee-x-trial-provision/apigee-x-trial-provision.sh
@@ -131,7 +131,7 @@ if [ "$CERTIFICATES" = "provided" ];then
 fi
 
 if [ -z "$PEERING_CIDR" ]; then
-  PEERING_CIDR_DISPLAY="[automatic /23 block]"
+  PEERING_CIDR_DISPLAY="[automatic /22 block]"
 else
   PEERING_CIDR_DISPLAY="$PEERING_CIDR"
 fi
@@ -192,7 +192,7 @@ if [[ "$NETWORK" =~ ^projects/.*/networks.*$ ]]; then
 else
   echo "Step 4.1: Define a range of reserved IP addresses for your network. "
   if [ -z "$PEERING_CIDR" ]; then
-    gcloud compute addresses create google-managed-services-default --global --prefix-length=23 \
+    gcloud compute addresses create google-managed-services-default --global --prefix-length=22 \
       --description="Peering range for Google Apigee X Tenant" --network="$NETWORK" \
       --purpose=VPC_PEERING --project="$PROJECT" --quiet || echo "Failed to create - ignoring assuming it already exists"
   else


### PR DESCRIPTION
What's changed, or what was fixed?

- the X trial org requires now /23 range prefix for peering CIDR

**Fixes:** #issue

- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.

**CC:** @apigee-devrel-reviewers
