### PR TITLE
check for xmllint on PATH

### DIFF
--- a/tools/apigee-openlegacy/bin/apigee-openlegacy.sh
+++ b/tools/apigee-openlegacy/bin/apigee-openlegacy.sh
@@ -51,7 +51,7 @@ GCP_REGION=${GCP_REGION:-europe-west1}
 # Check for required tools on path
 ###
 
-for TOOL in unzip ol gcloud jq node npm sackmesser; do
+for TOOL in unzip ol gcloud jq node npm sackmesser xmllint; do
   if ! which $TOOL > /dev/null; then
     echo "Please ensure $TOOL is installed and on your PATH"
     exit 1


### PR DESCRIPTION
when running in a minimal environment, it is likely that xmllint is not installed. This PR checks it is on the PATH before proceeding.

**CC:** @apigee-devrel-reviewers
