### PR TITLE
#332 fix sackmesser github reference without path or branch specified

### DIFF
--- a/tools/apigee-sackmesser/cmd/deploy/deploy.sh
+++ b/tools/apigee-sackmesser/cmd/deploy/deploy.sh
@@ -38,15 +38,20 @@ trap cleanup EXIT
 
 # copy resources to temp directory
 if [ -n "$url" ]; then
-    pattern='https?:\/\/github.com\/([^\/]*)\/([^\/]*)\/tree\/([^\/]*)\/(.*)'
+    pattern='https?:\/\/github.com\/([^\/]*)\/([^\/]*)(\/tree\/([^\/]*)(\/(.*))?)?'
+
     [[ "$url" =~ $pattern ]]
     git_org="${BASH_REMATCH[1]}"
     git_repo="${BASH_REMATCH[2]}"
-    git_branch="${BASH_REMATCH[3]}"
-    git_path="${BASH_REMATCH[4]}"
+    git_branch="${BASH_REMATCH[4]}"
+    git_path="${BASH_REMATCH[6]}"
 
     git clone "https://github.com/${git_org}/${git_repo}.git" "$temp_folder/$git_repo"
-    (cd "$temp_folder/$git_repo" && git checkout "$git_branch")
+
+    if [[ -n "$git_branch" ]]; then
+        (cd "$temp_folder/$git_repo" && git checkout "$git_branch")
+    fi
+
     cp -R "$temp_folder/$git_repo/$git_path/"* "$temp_folder"
 else
     source_dir="${directory:-$PWD}"


### PR DESCRIPTION
What's changed, or what was fixed?

- allow sackmesser deployments fir git references that do not contain a branch or path 

**Fixes:** #332 

- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.

**CC:** @apigee-devrel-reviewers
