### PR TITLE
use license in root folder only

### DIFF
--- a/references/apimocker-hostedtargets/package.json
+++ b/references/apimocker-hostedtargets/package.json
@@ -9,7 +9,6 @@
     "test": "npx cucumber-js test"
   },
   "author": "LaughingBiscuit",
-  "license": "Apache-2.0",
   "dependencies": {
     "@cucumber/cucumber": "^7.3.0",
     "apickli": "^3.0.0",

--- a/references/cicd-pipeline/package.json
+++ b/references/cicd-pipeline/package.json
@@ -3,13 +3,6 @@
   "version": "1.0.0",
   "description": "Sample Proxy for CI/CD Reference",
   "author": "danistrebel",
-  "license": "Apache-2.0",
-  "licenses": [
-    {
-      "type": "Apache-2.0",
-      "url": "http://www.apache.org/licenses/LICENSE-2.0"
-    }
-  ],
   "scripts": {
     "test": "npm run unit-test && npm run integration-test",
     "unit-test": "nyc --reporter=html mocha --recursive \"./test/unit/*.js\"",

--- a/references/cicd-sharedflow-pipeline/package.json
+++ b/references/cicd-sharedflow-pipeline/package.json
@@ -3,13 +3,6 @@
 	"version": "1.0.0",
 	"description": "Sample Sharedflow for CI/CD Reference",
 	"author": "ssvaidyanathan",
-	"license": "Apache-2.0",
-	"licenses": [
-		{
-			"type": "Apache-2.0",
-			"url": "http://www.apache.org/licenses/LICENSE-2.0"
-		}
-	],
 	"scripts": {
 		"eslint": "eslint --format json",
 		"apigeelint-sharedflow": "apigeelint -s ./sharedflowbundle -f table.js",

--- a/references/dutch-healthcare/healthcare-v1/package.json
+++ b/references/dutch-healthcare/healthcare-v1/package.json
@@ -4,7 +4,6 @@
   "scripts": {
     "test": "npm i && npx cucumber-js --retry 3 test"
   },
-  "license": "Apache-2.0",
   "dependencies": {
     "@cucumber/cucumber": "^7.3.0",
     "apickli": "^3.0.0",

--- a/references/kvm-admin-api/package.json
+++ b/references/kvm-admin-api/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "test": "npm i && npx cucumber-js --retry 10 --retry-tag-filter '@flaky' test"
   },
-  "license": "Apache-2.0",
   "dependencies": {
     "@cucumber/cucumber": "^7.3.0",
     "apickli": "^3.0.0"

--- a/references/proxy-template/template-v1/package.json
+++ b/references/proxy-template/template-v1/package.json
@@ -10,7 +10,6 @@
     "deploy": "npm i && npx apigeetool deployproxy -u $APIGEE_USER -p $APIGEE_PASS -o $APIGEE_ORG -e $APIGEE_ENV -n $npm_package_name -V",
     "test": "npm i && npx cucumber-js test"
   },
-  "license": "Apache-2.0",
   "dependencies": {
     "@cucumber/cucumber": "^7.3.0",
     "apickli": "^3.0.0",

--- a/tools/apigee-openlegacy/res/proxy/package.json
+++ b/tools/apigee-openlegacy/res/proxy/package.json
@@ -10,7 +10,6 @@
     "deploy": "npm i && npx apigeetool deployproxy -u $APIGEE_USER -p $APIGEE_PASS -o $APIGEE_ORG -e $APIGEE_ENV -n $npm_package_name -V",
     "test": "npm i && npx cucumber-js test"
   },
-  "license": "Apache-2.0",
   "dependencies": {
     "apickli": "^3.0.0",
     "apigeetool": "^0.10.0",

--- a/tools/apigee-sackmesser/test/package.json
+++ b/tools/apigee-sackmesser/test/package.json
@@ -3,7 +3,6 @@
     "version": "1.0.0",
     "description": "Sackmesser Example Proxy",
     "author": "danistrebel",
-    "license": "Apache-2.0",
     "licenses": [
         {
             "type": "Apache-2.0",

--- a/tools/oas-apigee-mock/package.json
+++ b/tools/oas-apigee-mock/package.json
@@ -5,7 +5,6 @@
   "bin": {
     "oas-apigee-mock": "bin/oas-apigee-mock"
   },
-  "license": "Apache License Version 2.0",
   "dependencies": {
     "@cucumber/cucumber": "7.3.0",
     "apickli": "3.0.0",


### PR DESCRIPTION
What's changed, or what was fixed?

- remove license entries from package.json files because we only carry the license at the root of the repository

**Fixes:** #335

- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.

**CC:** @apigee-devrel-reviewers
