### PR TITLE
bump jenkins CICD reference dependencies

### DIFF
--- a/references/cicd-pipeline/README.md
+++ b/references/cicd-pipeline/README.md
@@ -71,7 +71,7 @@ git commit -m "initial commit"
 git push -u origin feature/cicd-pipeline
 ```
 
-## Run Cloud Build Deployment
+## Orchestration using Run Cloud
 
 The instructions below explain how to trigger an Apigee CI/CD pipeline manually
 via the gcloud command and via a push trigger on a Google Source Repository.
@@ -170,7 +170,9 @@ gcloud beta builds triggers create cloud-source-repositories \
     --substitutions="_API_VERSION=apigee,_DEPLOYMENT_ORG=$APIGEE_ORG,_APIGEE_TEST_ENV=$APIGEE_ENV,_INT_TEST_HOST=$APIGEE_ORG-$APIGEE_ENV.apigee.net"
 ```
 
-## Run a Jenkins Deployment
+## Orchestration using Jenkins
+
+*Note:* Currently this Jenkins reference is designed for Apigee Edge only.
 
 ### Requirement: Jenkins Server
 

--- a/references/cicd-pipeline/README.md
+++ b/references/cicd-pipeline/README.md
@@ -15,6 +15,12 @@ The CICD pipeline consists of:
 - Integration testing of the deployed proxy using
   [apickli](https://github.com/apickli/apickli)
 
+It also contains an example configuration for running the CI/CD
+pipeline in an orchestration tool:
+
+- Using fully managed Google Cloud Build for Apigee X/hybrid and Edge
+- Using a self-managed Jenkins Server for Apigee Edge
+
 ## Development
 
 - Install dependencies:

--- a/references/cicd-pipeline/jenkins-build/jenkins-web/Dockerfile
+++ b/references/cicd-pipeline/jenkins-build/jenkins-web/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM jenkins/jenkins:2.285-alpine
+FROM jenkins/jenkins:2.302-alpine
 
 USER root
 RUN apk update && apk add --no-cache git maven nodejs npm

--- a/references/cicd-pipeline/jenkins-build/jenkins-web/additional-plugins.txt
+++ b/references/cicd-pipeline/jenkins-build/jenkins-web/additional-plugins.txt
@@ -1,3 +1,3 @@
-configuration-as-code:1.47
+configuration-as-code:1.51
 workflow-aggregator:2.6
 workflow-multibranch:2.22

--- a/references/cicd-pipeline/jenkins-build/plugins.txt
+++ b/references/cicd-pipeline/jenkins-build/plugins.txt
@@ -1,8 +1,8 @@
 cucumber-reports:5.5.0
-git:4.3.0
+git:4.8.0
 htmlpublisher:1.23
-junit:1.47
-matrix-project:1.18
-script-security:1.76
+junit:1.51
+matrix-project:1.19
+script-security:1.77
 token-macro:2.15
-workflow-step-api:2.23
+workflow-step-api:2.24

--- a/references/cicd-pipeline/pipeline.sh
+++ b/references/cicd-pipeline/pipeline.sh
@@ -39,13 +39,13 @@ gcloud builds submit --config=./ci-config/cloudbuild/cloudbuild.yaml \
 echo "[INFO] CICD Pipeline for Apigee Edge (Jenkins)"
 
 # because volume mounts don't work inside docker in docker without reference to the host file system
-cat << EOF >> /tmp/Dockerfile-jenkins-cicd
+cat << EOF >> ./Dockerfile-jenkins-cicd
 FROM ghcr.io/danistrebel/devrel/jenkinsfile-runner:latest
 COPY . /workspace
 RUN cp /workspace/ci-config/jenkins/Jenkinsfile /workspace/Jenkinsfile
 EOF
-docker build -f /tmp/Dockerfile-jenkins-cicd -t apigee/devrel-jenkinsfile-runner-airports:latest .
-rm /tmp/Dockerfile-jenkins-cicd
+docker build -f ./Dockerfile-jenkins-cicd -t apigee/devrel-jenkinsfile-runner-airports:latest .
+rm ./Dockerfile-jenkins-cicd
 
 docker run \
   -e APIGEE_USER \


### PR DESCRIPTION
What's changed, or what was fixed?

- Bump jenkins plugin versions
- Explicitly state that the Jenkins Example is for Apigee Edge only

- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.

**CC:** @apigee-devrel-reviewers
