### PR TITLE
Bump Apigee hybrid to 1.5.2

### DIFF
--- a/tools/hybrid-quickstart/steps.sh
+++ b/tools/hybrid-quickstart/steps.sh
@@ -36,7 +36,7 @@ set_config_params() {
     export GKE_CLUSTER_NAME=${GKE_CLUSTER_NAME:-apigee-hybrid}
     export GKE_CLUSTER_MACHINE_TYPE=${GKE_CLUSTER_MACHINE_TYPE:-e2-standard-4}
 
-    export APIGEE_CTL_VERSION='1.5.1'
+    export APIGEE_CTL_VERSION='1.5.2'
     export KPT_VERSION='v0.34.0'
     export CERT_MANAGER_VERSION='v1.2.0'
     export ASM_VERSION='1.8'


### PR DESCRIPTION
What's changed, or what was fixed?

- Apigee hybrid updated to release 1.5.2 see [release notes](https://cloud.google.com/apigee/docs/release/notes/apigee-release-notes#july-23,-2021---apigee-hybrid-v1.5.2)


- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.

**CC:** @apigee-devrel-reviewers
