### PR TITLE
Add base configuration file generation to oas-apigee-mock

### DIFF
--- a/tools/oas-apigee-mock/lib/commands/generateApi/generateProxyEndPoint.js
+++ b/tools/oas-apigee-mock/lib/commands/generateApi/generateProxyEndPoint.js
@@ -176,4 +176,10 @@ module.exports = async function generateProxyEndPoint(apiProxy, options, api) {
 
   const xmlString = root.end({ pretty: true, indent: '  ', newline: '\n' })
   await fs.writeFile(rootDirectory + '/proxies/default.xml', xmlString)
+
+  // Generate Base Configuration file
+  const baseConfig = builder.create('APIProxy')
+  baseConfig.att('name', apiProxy)
+  const baseXml = baseConfig.end({ pretty: true, indent: '  ', newline: '\n' })
+  await fs.writeFile(rootDirectory + '/' + apiProxy + '.xml', baseXml)
 }

--- a/tools/oas-apigee-mock/lib/commands/generateApi/generateProxyEndPoint.js
+++ b/tools/oas-apigee-mock/lib/commands/generateApi/generateProxyEndPoint.js
@@ -22,7 +22,7 @@ const verifyApiKey = require('../../policy_templates/security/apikey.js')
 const oasValidation = require('../../policy_templates/validation/oas-validation.js')
 
 module.exports = async function generateProxyEndPoint(apiProxy, options, api) {
-  let useCors
+
   let destination = options.destination || path.join(__dirname, '../../../api_bundles')
   if (destination.substr(-1) === '/') {
     destination = destination.substr(0, destination.length - 1)
@@ -170,11 +170,6 @@ module.exports = async function generateProxyEndPoint(apiProxy, options, api) {
   virtualhosts.forEach(function (virtualhost) {
     httpProxyConn.ele('VirtualHost', {}, virtualhost)
   })
-
-  if (useCors) {
-    const routeRule1 = root.ele('RouteRule', { name: 'noRoute' })
-    routeRule1.ele('Condition', {}, 'request.verb == "OPTIONS"')
-  }
 
   // No back end, Assign message policies are used for responses, add noroute RouteRule
   root.ele('RouteRule', { name: 'noroute' })

--- a/tools/oas-apigee-mock/test/api_bundles/oas-apigee-mock-orders-apikey-header/apiproxy/oas-apigee-mock-orders-apikey-header.xml
+++ b/tools/oas-apigee-mock/test/api_bundles/oas-apigee-mock-orders-apikey-header/apiproxy/oas-apigee-mock-orders-apikey-header.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!--
+ Copyright 2021 Google LLC
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<APIProxy name="oas-apigee-mock-orders-apikey-header"/>

--- a/tools/oas-apigee-mock/test/api_bundles/oas-apigee-mock-orders-apikey-query/apiproxy/oas-apigee-mock-orders-apikey-query.xml
+++ b/tools/oas-apigee-mock/test/api_bundles/oas-apigee-mock-orders-apikey-query/apiproxy/oas-apigee-mock-orders-apikey-query.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!--
+ Copyright 2021 Google LLC
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<APIProxy name="oas-apigee-mock-orders-apikey-query"/>

--- a/tools/oas-apigee-mock/test/api_bundles/oas-apigee-mock-orders/apiproxy/oas-apigee-mock-orders.xml
+++ b/tools/oas-apigee-mock/test/api_bundles/oas-apigee-mock-orders/apiproxy/oas-apigee-mock-orders.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0"?>
+<!--
+ Copyright 2021 Google LLC
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<APIProxy name="oas-apigee-mock-orders"/>


### PR DESCRIPTION
What's changed, or what was fixed?

- Adding functionality to generate a [base configuration file](https://docs.apigee.com/api-platform/reference/api-proxy-configuration-reference#baseconfiguration-apiproxyweatherapixml) as part of proxy bundle generation. This file is required when deploying proxy bundles with Maven and Apigee Sackmesser.

- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.

**CC:** @apigee-devrel-reviewers
