### PR TITLE
Add apigee runtime to Service account cleanup

### DIFF
--- a/tools/hybrid-quickstart/steps.sh
+++ b/tools/hybrid-quickstart/steps.sh
@@ -466,7 +466,7 @@ create_self_signed_cert() {
   kubectl create secret tls tls-hybrid-ingress \
     --cert="$HYBRID_HOME/certs/$ENV_GROUP_NAME.fullchain.crt" \
     --key="$HYBRID_HOME/certs/$ENV_GROUP_NAME.key" \
-    -n istio-system
+    -n istio-system --dry-run -o yaml | kubectl apply -f -
 }
 
 create_sa() {
@@ -587,7 +587,7 @@ deploy_example_proxy() {
 }
 
 delete_apigee_keys() {
-  for SA in mart cassandra udca metrics synchronizer logger watcher distributed-trace
+  for SA in mart cassandra udca metrics synchronizer logger watcher distributed-trace runtime
   do
     delete_sa_keys "apigee-${SA}"
   done


### PR DESCRIPTION
What's changed, or what was fixed?

- Service account keys were not correctly cleaned up because the new SA in 1.5.2 (apigee-runtime) was missing
- Adding option to patch Apigee TLS secrets if re-installed on existing cluster

**Fixes:** #351 

- [X] I have run all the tests locally and they all pass.
- [X] I have followed the relevant style guide for my changes.

**CC:** @apigee-devrel-reviewers
