### PR TITLE
trusted certficiate for Apigee hybrid quickstart

### DIFF
--- a/tools/hybrid-quickstart/README.md
+++ b/tools/hybrid-quickstart/README.md
@@ -106,6 +106,18 @@ records. The quickstart checks if the `apigee-dns-zone` already exists and will
 skip its creation.
 If you use the default `DNS_NAME` you don't have to manually create a dns zone.
 
+## TLS/SSL Certificates
+
+You can use one of three different ways to issue TLS certificates for your
+Apigee hybrid ingress:
+
+- `export CERT_TYPE=''` (default) Automatically obtain trusted certificates (through
+  Let's encrypt). For details see [this](https://community.apigee.com/articles/86322/free-trusted-ssl-certificates-for-apigee-hybrid-in.html)
+  blog post in the Apigee community.
+- `export CERT_TYPE='self-signed'` creates self-signed certifificates
+- `export CERT_TYPE='skip'` skips the certificate creation and relies on you
+  creating a `tls-hybrid-ingress` certificate in the `istio-system` namespace.
+
 ## Initialize the Apigee hybrid runtime on a GKE cluster
 
 After the configuration is done run the following command to initialize you
@@ -115,11 +127,6 @@ Apigee hybrid organization and runtime. This typically takes between 15 and
 ```sh
 ./initialize-runtime-gke.sh
 ```
-
-## (Optional) Provision Trusted TLS/SSL Certificates
-
-See the [this](https://community.apigee.com/articles/86322/free-trusted-ssl-certificates-for-apigee-hybrid-in.html)
- blog post in the Apigee community.
 
 ## Clean up
 

--- a/tools/hybrid-quickstart/cloudbuild.yaml
+++ b/tools/hybrid-quickstart/cloudbuild.yaml
@@ -25,6 +25,9 @@ steps:
   env:
     - 'ENV_NAME=$_QUICKSTART_ENV_NAME'
     - 'ENV_GROUP_NAME=$_QUICKSTART_ENV_GROUP_NAME'
+    - 'CERT_TYPE=$_CERT_TYPE'
+    - 'QUIET_INSTALL=true'
+
 
 # Test that the proxy is successfully deployed
 - name: gcr.io/cloud-builders/gcloud
@@ -63,3 +66,4 @@ substitutions:
   _QUICKSTART_ENV_NAME: test1
   _QUICKSTART_ENV_GROUP_NAME: test
   _DESTROY_AFTER_VALIDATION: "false"
+  _CERT_TYPE: "" # default (let's encrypt)

--- a/tools/hybrid-quickstart/initialize-runtime-gke.sh
+++ b/tools/hybrid-quickstart/initialize-runtime-gke.sh
@@ -30,6 +30,9 @@ enable_all_apis
 # configure installation
 set_config_params
 
+# ask for confirmation (skip with QUIET_INSTALL=true)
+ask_confirm
+
 # create an Apigee organization with the same name as the GCP project
 create_apigee_org
 
@@ -60,8 +63,9 @@ download_apigee_ctl
 # configure the Apigee override parameters
 prepare_resources
 
-# create self-signed certificate for env group hostname
-create_self_signed_cert $ENV_GROUP_NAME
+# create certificate for env group hostname
+
+create_cert $ENV_GROUP_NAME
 
 # create all required service accounts and download their keys
 create_sa

--- a/tools/hybrid-quickstart/steps.sh
+++ b/tools/hybrid-quickstart/steps.sh
@@ -30,26 +30,32 @@ set_config_params() {
     export ZONE=${ZONE:-'europe-west1-c'}
     gcloud config set compute/zone "$ZONE"
 
+    printf "\n🔧 Apigee hybrid Configuration:\n"
     export INGRESS_TYPE=${INGRESS_TYPE:-'external'} # internal|external
+    echo "- Ingress type $INGRESS_TYPE"
+    echo "- TLS Certificate ${CERT_TYPE:-let\'s encrypt}"
 
-    echo "🔧 Configuring Apigee hybrid"
     export GKE_CLUSTER_NAME=${GKE_CLUSTER_NAME:-apigee-hybrid}
     export GKE_CLUSTER_MACHINE_TYPE=${GKE_CLUSTER_MACHINE_TYPE:-e2-standard-4}
-
-    export APIGEE_CTL_VERSION='1.5.2'
+    echo "- GKE Node Type $GKE_CLUSTER_MACHINE_TYPE"
+    export APIGEE_CTL_VERSION='1.5.3'
+    echo "- Apigeectl version $APIGEE_CTL_VERSION"
     export KPT_VERSION='v0.34.0'
+    echo "- kpt version $KPT_VERSION"
     export CERT_MANAGER_VERSION='v1.2.0'
+    echo "- Cert Manager version $CERT_MANAGER_VERSION"
     export ASM_VERSION='1.8'
+    echo "- ASM version $ASM_VERSION"
 
     OS_NAME=$(uname -s)
 
     if [[ "$OS_NAME" == "Linux" ]]; then
-      echo "🐧 Using Linux binaries"
+      echo "- 🐧 Using Linux binaries"
       export APIGEE_CTL='apigeectl_linux_64.tar.gz'
       export KPT_BINARY='kpt_linux_amd64-0.34.0.tar.gz'
       export JQ_VERSION='jq-1.6/jq-linux64'
     elif [[ "$OS_NAME" == "Darwin" ]]; then
-      echo "🍏 Using macOS binaries"
+      echo "- 🍏 Using macOS binaries"
       export APIGEE_CTL='apigeectl_mac_64.tar.gz'
       export KPT_BINARY='kpt_darwin_amd64-0.34.0.tar.gz'
       export JQ_VERSION='jq-1.6/jq-osx-amd64'
@@ -58,24 +64,30 @@ set_config_params() {
       exit 2
     fi
 
-    echo "🔧 Setting derived config parameters"
+
+    printf "\n🔧 Derived config parameters\n"
+    echo "- GCP Project $PROJECT_ID"
     PROJECT_NUMBER=$(gcloud projects describe "${PROJECT_ID}" --format="value(projectNumber)")
     export PROJECT_NUMBER
     export WORKLOAD_POOL="${PROJECT_ID}.svc.id.goog"
+    echo "- Workload Pool $WORKLOAD_POOL"
     export MESH_ID="proj-${PROJECT_NUMBER}"
+    echo "- Mesh ID $MESH_ID"
 
     # these will be set if the steps are run in order
     INGRESS_IP=$(gcloud compute addresses list --format json --filter "name=apigee-ingress-ip" --format="get(address)" || echo "")
     export INGRESS_IP
+    echo "- Ingress IP ${INGRESS_IP:-N/A}"
     NAME_SERVER=$(gcloud dns managed-zones describe apigee-dns-zone --format="json" --format="get(nameServers[0])" 2>/dev/null || echo "")
     export NAME_SERVER
+    echo "- Nameserver ${NAME_SERVER:-N/A}"
 
     export QUICKSTART_ROOT="${QUICKSTART_ROOT:-$PWD}"
     export QUICKSTART_TOOLS="$QUICKSTART_ROOT/tools"
     export APIGEECTL_HOME=$QUICKSTART_TOOLS/apigeectl/apigeectl_$APIGEE_CTL_VERSION
     export HYBRID_HOME=$QUICKSTART_ROOT/hybrid-files
 
-    echo "Running hybrid quickstart script from: $QUICKSTART_ROOT"
+    echo "- Script root from: $QUICKSTART_ROOT"
 }
 
 token() { echo -n "$(gcloud config config-helper --force-auth-refresh | grep access_token | grep -o -E '[^ ]+$')" ; }
@@ -108,6 +120,19 @@ function wait_for_ready(){
     done
 }
 
+ask_confirm() {
+  if [ ! "$QUIET_INSTALL" = "true" ]; then
+    printf "\n\n"
+    read -p "Do you want to continue with the config above? [Y/n]: " -n 1 -r REPLY; printf "\n"
+    REPLY=${REPLY:-Y}
+
+    if [[ "$REPLY" =~ ^[Yy]$ ]]; then
+      echo "starting provisioning"
+    else
+      exit 1
+    fi
+  fi
+}
 
 check_existing_apigee_resource() {
   RESOURCE_URI=$1
@@ -130,12 +155,6 @@ enable_all_apis() {
   PROJECT_ID=${PROJECT_ID:-$(gcloud config get-value "project")}
 
   echo "📝 Enabling all required APIs in GCP project \"$PROJECT_ID\""
-
-  # Assuming we already enabled the APIs if the Apigee Org exists
-  if check_existing_apigee_resource "https://apigee.googleapis.com/v1/organizations/$PROJECT_ID" ; then
-    echo "(assuming APIs are already enabled)"
-    return
-  fi
   echo -n "⏳ Waiting for APIs to be enabled"
 
   gcloud services enable \
@@ -166,7 +185,7 @@ create_apigee_org() {
 
     if check_existing_apigee_resource "https://apigee.googleapis.com/v1/organizations/$PROJECT_ID" ; then
       echo "(skipping org creation, already exists)"
-      return
+      return 0
     fi
 
     curl -X POST --fail -H "Authorization: Bearer $(token)" -H "content-type:application/json" \
@@ -441,32 +460,69 @@ prepare_resources() {
     echo "✅ Hybrid Config Setup"
 }
 
-create_self_signed_cert() {
+create_cert() {
 
   ENV_GROUP_NAME=$1
 
-  echo "🙈 Creating self-signed cert - $ENV_GROUP_NAME"
-  mkdir  -p "$HYBRID_HOME/certs"
+  if [ "$CERT_TYPE" = "self-signed" ];then
+    echo "🙈 Creating self-signed cert - $ENV_GROUP_NAME"
+    mkdir  -p "$HYBRID_HOME/certs"
 
-  CA_CERT_NAME="quickstart-ca"
+    CA_CERT_NAME="quickstart-ca"
 
-  # create CA cert if not exist
-  if [ -f "$HYBRID_HOME/certs/$CA_CERT_NAME.crt" ]; then
-    echo "CA already exists! Reusing that one."
+    # create CA cert if not exist
+    if [ -f "$HYBRID_HOME/certs/$CA_CERT_NAME.crt" ]; then
+      echo "CA already exists! Reusing that one."
+    else
+      openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -subj "/CN=$DNS_NAME/O=Apigee Quickstart" -keyout "$HYBRID_HOME/certs/$CA_CERT_NAME.key" -out "$HYBRID_HOME/certs/$CA_CERT_NAME.crt"
+    fi
+
+    openssl req -out "$HYBRID_HOME/certs/$ENV_GROUP_NAME.csr" -newkey rsa:2048 -nodes -keyout "$HYBRID_HOME/certs/$ENV_GROUP_NAME.key" -subj "/CN=$ENV_GROUP_NAME.$DNS_NAME/O=Apigee Quickstart"
+
+    openssl x509 -req -days 365 -CA "$HYBRID_HOME/certs/$CA_CERT_NAME.crt" -CAkey "$HYBRID_HOME/certs/$CA_CERT_NAME.key" -set_serial 0 -in "$HYBRID_HOME/certs/$ENV_GROUP_NAME.csr" -out "$HYBRID_HOME/certs/$ENV_GROUP_NAME.crt"
+
+    cat "$HYBRID_HOME/certs/$ENV_GROUP_NAME.crt" "$HYBRID_HOME/certs/$CA_CERT_NAME.crt" > "$HYBRID_HOME/certs/$ENV_GROUP_NAME.fullchain.crt"
+
+    kubectl create secret tls tls-hybrid-ingress \
+      --cert="$HYBRID_HOME/certs/$ENV_GROUP_NAME.fullchain.crt" \
+      --key="$HYBRID_HOME/certs/$ENV_GROUP_NAME.key" \
+      -n istio-system --dry-run -o yaml | kubectl apply -f -
+
+  elif [ "$CERT_TYPE" = "skip" ];then
+    return
   else
-    openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 -subj "/CN=$DNS_NAME/O=Apigee Quickstart" -keyout "$HYBRID_HOME/certs/$CA_CERT_NAME.key" -out "$HYBRID_HOME/certs/$CA_CERT_NAME.crt"
+    echo "🔒 Creating let's encrypt cert - $ENV_GROUP_NAME"
+    cat <<EOF | kubectl apply -f -
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: letsencrypt
+  namespace: istio-system
+spec:
+  acme:
+    email: admin@$DNS_NAME
+    server: https://acme-v02.api.letsencrypt.org/directory
+    privateKeySecretRef:
+      name: letsencrypt-issuer-account-key
+    solvers:
+    - http01:
+       ingress:
+         class: istio
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: tls-hybrid-ingress
+  namespace: istio-system
+spec:
+  secretName: tls-hybrid-ingress
+  issuerRef:
+    name: letsencrypt
+  commonName: $ENV_GROUP_NAME.$DNS_NAME
+  dnsNames:
+  - $ENV_GROUP_NAME.$DNS_NAME
+EOF
   fi
-
-  openssl req -out "$HYBRID_HOME/certs/$ENV_GROUP_NAME.csr" -newkey rsa:2048 -nodes -keyout "$HYBRID_HOME/certs/$ENV_GROUP_NAME.key" -subj "/CN=$ENV_GROUP_NAME.$DNS_NAME/O=Apigee Quickstart"
-
-  openssl x509 -req -days 365 -CA "$HYBRID_HOME/certs/$CA_CERT_NAME.crt" -CAkey "$HYBRID_HOME/certs/$CA_CERT_NAME.key" -set_serial 0 -in "$HYBRID_HOME/certs/$ENV_GROUP_NAME.csr" -out "$HYBRID_HOME/certs/$ENV_GROUP_NAME.crt"
-
-  cat "$HYBRID_HOME/certs/$ENV_GROUP_NAME.crt" "$HYBRID_HOME/certs/$CA_CERT_NAME.crt" > "$HYBRID_HOME/certs/$ENV_GROUP_NAME.fullchain.crt"
-
-  kubectl create secret tls tls-hybrid-ingress \
-    --cert="$HYBRID_HOME/certs/$ENV_GROUP_NAME.fullchain.crt" \
-    --key="$HYBRID_HOME/certs/$ENV_GROUP_NAME.key" \
-    -n istio-system --dry-run -o yaml | kubectl apply -f -
 }
 
 create_sa() {
@@ -578,12 +634,13 @@ deploy_example_proxy() {
 
   echo "🤓 Try without DNS (first deployment takes a few seconds. Relax and breathe!):"
 
-  if echo "$DNS_NAME" | grep -q ".nip.io"; then
+  if [ "$CERT_TYPE" = "self-signed" ];then
    echo "curl --cacert $QUICKSTART_ROOT/hybrid-files/certs/quickstart-ca.crt https://$ENV_GROUP_NAME.$DNS_NAME/httpbin/v0/anything"
   else
-    echo "curl --cacert $QUICKSTART_ROOT/hybrid-files/certs/quickstart-ca.crt --resolve $ENV_GROUP_NAME.$DNS_NAME:443:$INGRESS_IP https://$ENV_GROUP_NAME.$DNS_NAME/httpbin/v0/anything"
-    echo "👋 To reach it via the FQDN: Make sure you add this as an NS record for $DNS_NAME: $NAME_SERVER"
+    echo "curl https://$ENV_GROUP_NAME.$DNS_NAME/httpbin/v0/anything"
   fi
+  echo "👋 To reach your API via the FQDN: Make sure you add a DNS record for your FQDN or an NS record for $DNS_NAME: $NAME_SERVER"
+  echo "👋 During development you can also use --resolve $ENV_GROUP_NAME.$DNS_NAME:443:$INGRESS_IP to resolve the hostname for your curl command"
 }
 
 delete_apigee_keys() {


### PR DESCRIPTION
What's changed, or what was fixed?

- Use trusted (let's encrypt) cert for hybrid quickstart with alternative options
  - BYOC
  - Self-signed
- Bump to patch release `1.5.2` -> `1.5.3`
- More config output before running install
- Always run enable APIs 

- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.

**CC:** @apigee-devrel-reviewers
