### PR TITLE
Cloud Logging via GCP Service Account

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,6 +2,7 @@
 
 /references/cicd-pipeline             @danistrebel
 /references/cicd-sharedflow-pipeline  @ssvaidyanathan
+/references/cloud-logging-shared-flow @danistrebel
 /references/gcp-sa-auth-shared-flow   @danistrebel
 /references/identity-facade           @joelgauci
 /references/js-callout                @seymen

--- a/README.md
+++ b/README.md
@@ -24,9 +24,11 @@ further to fit a particular use case.
 - [CI/CD Pipeline](references/cicd-pipeline) -
   Reference implementation for a CI/CD Pipeline using the Apigee
   Deploy Maven Plugin and a choice of either Jenkins or Google Cloud Build
-- [CI/CD Pipeline for SharedFlows](references/cicd-sharedflow-pipeline) -
+- [CI/CD Pipeline for Shared Flows](references/cicd-sharedflow-pipeline) -
   Reference implementation for a CI/CD Pipeline for Sharedflows using the Apigee
   Deploy Maven Plugin
+- [Cloud Logging Shared Flow](references/cloud-logging-shared-flow) -
+  Reference implementation for a shared flow to log to Google Cloud Logging
 - [Proxy Template](references/proxy-template) -
   An extensible templating tool to bootstrap API proxies containing Security,
   Traffic Management, Error Handling

--- a/references/cloud-logging-shared-flow/README.md
+++ b/references/cloud-logging-shared-flow/README.md
@@ -6,7 +6,7 @@ from within an Apigee Proxy.
 ## Compatibility
 
 This example is built using the [GCP Service Account Association](https://cloud.google.com/apigee/docs/api-platform/security/google-auth/overview)
-that is available in Apigee X. For scenarios where this this option is not
+that is available in Apigee X. For scenarios where this option is not
 available you could make use of the [GCP SA shared flow](../gcp-sa-auth-shared-flow)
 to obtain a valid access token and use it within the ServiceCallout policy.
 

--- a/references/cloud-logging-shared-flow/README.md
+++ b/references/cloud-logging-shared-flow/README.md
@@ -1,0 +1,25 @@
+# Cloud Logging Shared Flow
+
+Reference implementation for a shared flow to log to [Google Cloud Logging](https://cloud.google.com/logging)
+from within an Apigee Proxy.
+
+## Compatibility
+
+This example is built using the [GCP Service Account Association](https://cloud.google.com/apigee/docs/api-platform/security/google-auth/overview)
+that is available in Apigee X. For scenarios where this this option is not
+available you could make use of the [GCP SA shared flow](../gcp-sa-auth-shared-flow)
+to obtain a valid access token and use it within the ServiceCallout policy.
+
+## Usage
+
+```sh
+alias sackmesser=${PWD}/../../tools/apigee-sackmesser/bin/sackmesser
+
+export APIGEE_X_ORG=<my-org>
+export APIGEE_X_ENG=<my-env>
+export APIGEE_X_HOSTNAME=<my-hostname>
+
+export CLOUD_LOG_WRITER_SA=<gcp service account email to be used by the logger>
+
+./pipeline.sh
+```

--- a/references/cloud-logging-shared-flow/pipeline.sh
+++ b/references/cloud-logging-shared-flow/pipeline.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e
+
+SCRIPTPATH=$( (cd "$(dirname "$0")" && pwd ))
+
+APIGEE_TOKEN=$(gcloud auth print-access-token);
+
+SA_EMAIL="cloud-log-writer@$APIGEE_X_ORG.iam.gserviceaccount.com"
+
+EXISTING_EMAIL=$(gcloud iam service-accounts list --filter="email=$SA_EMAIL" --format="get(email)" --project "$APIGEE_X_ORG")
+
+if [ "$EXISTING_EMAIL" != "$SA_EMAIL" ]; then
+  gcloud iam service-accounts create "cloud-log-writer" --project "$APIGEE_X_ORG"
+  gcloud projects add-iam-policy-binding "$APIGEE_X_ORG" \
+    --member="serviceAccount:$SA_EMAIL" \
+    --role="roles/logging.logWriter"
+fi
+
+
+
+sackmesser deploy --googleapi -d "$SCRIPTPATH" -t "$APIGEE_TOKEN" --deployment-sa "$SA_EMAIL"
+sackmesser deploy --googleapi -d "$SCRIPTPATH/test/logging-example" -t "$APIGEE_TOKEN"
+
+TEST_PATH="/logging-example?t=$(date +%s)"
+curl "https://${APIGEE_X_HOSTNAME}${TEST_PATH}" -I
+
+i=0
+logs_count=0
+while [ "$i" -lt 20 ] && [ ! "$logs_count" -gt 0 ]; do
+    i=$(( i + 1 ))
+    logs_count=$(gcloud logging read "logName=projects/$APIGEE_X_ORG/logs/apigee-runtime AND jsonPayload.requestUri=\"$TEST_PATH\"" --limit 5 --format=json --project "$APIGEE_X_ORG" | jq '. | length')
+    echo "(attempt $i) logs found: $logs_count"
+    sleep 1
+done
+
+if [ "$logs_count" -eq 0 ]; then
+    echo "No logs found for test path $TEST_PATH"
+    exit 1
+fi

--- a/references/cloud-logging-shared-flow/sharedflowbundle/cloud-logging-v1.xml
+++ b/references/cloud-logging-shared-flow/sharedflowbundle/cloud-logging-v1.xml
@@ -1,0 +1,16 @@
+<!--
+Copyright 2021 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<SharedFlowBundle revision="1" name="cloud-logging-v1"/>

--- a/references/cloud-logging-shared-flow/sharedflowbundle/policies/SC.CloudLogging.xml
+++ b/references/cloud-logging-shared-flow/sharedflowbundle/policies/SC.CloudLogging.xml
@@ -62,7 +62,7 @@ limitations under the License.
         <Authentication>
             <GoogleAccessToken>
                 <Scopes>
-                    <Scope>https://www.googleapis.com/auth/cloud-platform</Scope>
+                    <Scope>https://www.googleapis.com/auth/logging.write</Scope>
                 </Scopes>
                 <LifetimeInSeconds>3600</LifetimeInSeconds>
             </GoogleAccessToken>

--- a/references/cloud-logging-shared-flow/sharedflowbundle/policies/SC.CloudLogging.xml
+++ b/references/cloud-logging-shared-flow/sharedflowbundle/policies/SC.CloudLogging.xml
@@ -1,0 +1,77 @@
+<!--
+Copyright 2021 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<ServiceCallout name="SC.CloudLogging">
+    <Request>
+        <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
+        <Set>
+            <Payload contentType="application/json">{
+    "logName": "projects/{organization.name}/logs/apigee-runtime",
+    "resource" : {
+      "type": "api",
+      "labels": {}
+    },
+    "labels": {
+        "application": "apigee"
+    },
+    "entries": [{
+        "severity": "INFO",
+        "jsonPayload": {
+            "organization": "{organization.name}",
+            "environment": "{environment.name}",
+            "apiProxy": "{apiproxy.name}",
+            "apiProxyRevision": "{apiproxy.revision}",
+            "apiProduct": "{apiproduct.name}",
+            "developerApp": "{apiproduct.name}",
+            "clientId": "{client_id}",
+            "developerId": "{developer.id}",
+            "requestUri": "{request.uri}",
+            "requestUrl": "{request.url}",
+            "verb": "{request.verb}",
+            "correlationId": "{messageid}",
+            "proxyRequestReceived": "{client.received.end.timestamp}",
+            "proxyResponseSent": "{client.sent.end.timestamp}",
+            "targetResponseReceived": "{target.received.end.timestamp}",
+            "targetRequestSent": "{target.sent.end.timestamp}",
+            "targetResponseCode": "{message.status.code}",
+            "proxyResponseCode": "{response.status.code}",
+            "faultName":"{fault.name}"
+        }
+    }],
+    "partialSuccess": true
+  }
+</Payload>
+            <Verb>POST</Verb>
+        </Set>
+    </Request>
+
+    <Response>loggingresponse</Response>
+
+    <HTTPTargetConnection>
+        <Authentication>
+            <GoogleAccessToken>
+                <Scopes>
+                    <Scope>https://www.googleapis.com/auth/cloud-platform</Scope>
+                </Scopes>
+                <LifetimeInSeconds>3600</LifetimeInSeconds>
+            </GoogleAccessToken>
+        </Authentication>
+        <Properties>
+            <Property name="success.codes">2xx, 3xx</Property>
+        </Properties>
+        <URL>https://logging.googleapis.com/v2/entries:write</URL>
+    </HTTPTargetConnection>
+</ServiceCallout>

--- a/references/cloud-logging-shared-flow/sharedflowbundle/policies/SC.CloudLogging.xml
+++ b/references/cloud-logging-shared-flow/sharedflowbundle/policies/SC.CloudLogging.xml
@@ -58,8 +58,6 @@ limitations under the License.
         </Set>
     </Request>
 
-    <Response>loggingresponse</Response>
-
     <HTTPTargetConnection>
         <Authentication>
             <GoogleAccessToken>

--- a/references/cloud-logging-shared-flow/sharedflowbundle/policies/SC.CloudLogging.xml
+++ b/references/cloud-logging-shared-flow/sharedflowbundle/policies/SC.CloudLogging.xml
@@ -53,7 +53,7 @@ limitations under the License.
     }],
     "partialSuccess": true
   }
-</Payload>
+            </Payload>
             <Verb>POST</Verb>
         </Set>
     </Request>
@@ -67,9 +67,6 @@ limitations under the License.
                 <LifetimeInSeconds>3600</LifetimeInSeconds>
             </GoogleAccessToken>
         </Authentication>
-        <Properties>
-            <Property name="success.codes">2xx, 3xx</Property>
-        </Properties>
         <URL>https://logging.googleapis.com/v2/entries:write</URL>
     </HTTPTargetConnection>
 </ServiceCallout>

--- a/references/cloud-logging-shared-flow/sharedflowbundle/sharedflows/default.xml
+++ b/references/cloud-logging-shared-flow/sharedflowbundle/sharedflows/default.xml
@@ -1,0 +1,21 @@
+<!--
+ Copyright 2021 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<SharedFlow name="default">
+    <Step>
+        <Name>SC.CloudLogging</Name>
+    </Step>
+</SharedFlow>

--- a/references/cloud-logging-shared-flow/test/logging-example/apiproxy/logging-example.xml
+++ b/references/cloud-logging-shared-flow/test/logging-example/apiproxy/logging-example.xml
@@ -1,0 +1,17 @@
+<!--
+Copyright 2021 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<APIProxy revision="1" name="logging-example"/>

--- a/references/cloud-logging-shared-flow/test/logging-example/apiproxy/policies/FC.CloudLogging.xml
+++ b/references/cloud-logging-shared-flow/test/logging-example/apiproxy/policies/FC.CloudLogging.xml
@@ -1,0 +1,19 @@
+<!--
+Copyright 2021 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<FlowCallout name="FC.CloudLogging">
+    <SharedFlowBundle>cloud-logging-v1</SharedFlowBundle>
+</FlowCallout>

--- a/references/cloud-logging-shared-flow/test/logging-example/apiproxy/proxies/default.xml
+++ b/references/cloud-logging-shared-flow/test/logging-example/apiproxy/proxies/default.xml
@@ -1,0 +1,35 @@
+<!--
+Copyright 2021 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+<ProxyEndpoint name="default">
+    <PreFlow name="PreFlow">
+        <Request>
+            <Step>
+                <Name>FC.CloudLogging</Name>
+            </Step>
+        </Request>
+        <Response/>
+    </PreFlow>
+    <Flows/>
+    <PostFlow name="PostFlow">
+        <Request/>
+        <Response/>
+    </PostFlow>
+    <HTTPProxyConnection>
+        <BasePath>/logging-example</BasePath>
+    </HTTPProxyConnection>
+    <RouteRule name="noroute"/>
+</ProxyEndpoint>

--- a/tools/apigee-sackmesser/README.md
+++ b/tools/apigee-sackmesser/README.md
@@ -39,6 +39,7 @@ help
 clean
 
 Options:
+Options:
 --googleapi (default), use apigee.googleapis.com (for X, hybrid)
 --apigeeapi, use api.enterprise.apigee.com (for Edge)
 -b,--base-path, overrides the default base path for the API proxy
@@ -54,8 +55,9 @@ Options:
 -t,--token, GCP token (X,hybrid only) or OAuth2 token (Edge)
 -u,--username, Apigee User Name (Edge only)
 --async, Asynchronous deployment option (X,hybrid only)
---description, Human friendly proxy or shared flow description
 --debug, show verbose debug output
+--deployment-sa, GCP Service Account to associate with the deployment (X,hybrid only)
+--description, Human friendly proxy or shared flow description
 ```
 
 ## CLI Examples

--- a/tools/apigee-sackmesser/bin/sackmesser
+++ b/tools/apigee-sackmesser/bin/sackmesser
@@ -49,8 +49,9 @@ Options:
 -t,--token, GCP token (X,hybrid only) or OAuth2 token (Edge)
 -u,--username, Apigee User Name (Edge only)
 --async, Asynchronous deployment option (X,hybrid only)
---description, Human friendly proxy or shared flow description
 --debug, show verbose debug output
+--deployment-sa, GCP Service Account to associate with the deployment (X,hybrid only)
+--description, Human friendly proxy or shared flow description
 EOF
 }
 
@@ -73,31 +74,32 @@ while [ "$#" -gt 0 ]; do
     -d) export directory="$2"; shift 2;;
     -e) export environment="$2"; shift 2;;
     -g) export url="$2"; shift 2;;
+    -h) export hostname="$2"; shift 2;;
+    -L) export baseuri="$2"; shift 2;;
     -m) export mfa="$2"; shift 2;;
     -n) export bundle_name="$2"; shift 2;;
     -o) export organization="$2"; shift 2;;
     -p) export password="$2"; shift 2;;
     -t) export token="$2"; shift 2;;
     -u) export username="$2"; shift 2;;
-    -h) export hostname="$2"; shift 2;;
-    -L) export baseuri="$2"; shift 2;;
 
     --async) export deploy_options="async"; shift 1;;
-    --directory) export directory="${2}"; shift 2;;
-    --github) export url="${2}"; shift 2;;
-    --token) export token="${2}"; shift 2;;
-    --mfa) export mfa="${2}"; shift 2;;
-    --name) export bundle_name="${2}"; shift 2;;
     --base-path) export base_path="${2}"; shift 2;;
-    --username) export username="${2}"; shift 2;;
-    --password) export password="${2}"; shift 2;;
-    --environment) export environment="${2}"; shift 2;;
-    --organization) export organization="${2}"; shift 2;;
-    --hostname) export hostname="${2}"; shift 2;;
-    --description) export description="${2}"; shift 2;;
     --baseuri) export baseuri="${2}"; shift 2;;
     --debug) export debug="T"; shift 1;;
+    --deployment-sa) export deployment_sa="${2}"; shift 2;;
+    --description) export description="${2}"; shift 2;;
+    --directory) export directory="${2}"; shift 2;;
+    --environment) export environment="${2}"; shift 2;;
+    --github) export url="${2}"; shift 2;;
+    --hostname) export hostname="${2}"; shift 2;;
+    --mfa) export mfa="${2}"; shift 2;;
+    --name) export bundle_name="${2}"; shift 2;;
+    --organization) export organization="${2}"; shift 2;;
+    --password) export password="${2}"; shift 2;;
     --quiet) export quiet="T"; shift 1;;
+    --token) export token="${2}"; shift 2;;
+    --username) export username="${2}"; shift 2;;
 
     --apigeeapi) export apiversion="apigee"; shift 1;;
     --googleapi) export apiversion="google"; shift 1;;

--- a/tools/apigee-sackmesser/cmd/deploy/deploy.sh
+++ b/tools/apigee-sackmesser/cmd/deploy/deploy.sh
@@ -153,7 +153,8 @@ if [ "$apiversion" = "google" ]; then
         -Dproxy.name="$bundle_name" \
         -Dtoken="$token" \
         -Dapigee.options="${deploy_options:-override}" \
-        -Dapigee.config.options="${config_action:-none}")
+        -Dapigee.config.options="${config_action:-none}" \
+        -Dapigee.depoloyment.sa="${deployment_sa}")
 elif [ "$apiversion" = "apigee" ]; then
     # install for apigee Edge
     cp "$SCRIPT_FOLDER/pom-edge.xml" "$temp_folder/pom.xml"

--- a/tools/apigee-sackmesser/cmd/deploy/pom-hybrid.xml
+++ b/tools/apigee-sackmesser/cmd/deploy/pom-hybrid.xml
@@ -52,11 +52,12 @@ limitations under the License.
 		<apigee.apiversion>v1</apigee.apiversion>
 		<apigee.org>${org}</apigee.org>
 		<apigee.env>${env}</apigee.env>
-		<apigee.plugin.version>2.1.0</apigee.plugin.version>
+		<apigee.plugin.version>2.1.2</apigee.plugin.version>
 		<apigee.config-plugin.version>2.1.1</apigee.config-plugin.version>
 		<apigee.hosturl>https://${baseuri}</apigee.hosturl>
-		<apigee.bearer>${token}</apigee.bearer> <!-- this takes precedence over service account file -->
+		<apigee.bearer>${token}</apigee.bearer>
 		<apigee.apitype>${apitype}</apigee.apitype>
+		<apigee.googletoken.email>${apigee.depoloyment.sa}</apigee.googletoken.email>
 	</properties>
 
 	<build>


### PR DESCRIPTION
What's changed, or what was fixed?

- New Reference to Log to Cloud Logging via GCP Service Account
- Service Account attachment for Sackmesser Deployments

**Fixes:** #359

- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.

**CC:** @apigee-devrel-reviewers
