### PR TITLE
update asm service annotations

### DIFF
--- a/tools/hybrid-quickstart/steps.sh
+++ b/tools/hybrid-quickstart/steps.sh
@@ -374,6 +374,9 @@ install_asm() {
   curl --fail https://storage.googleapis.com/csm-artifacts/asm/install_asm_$ASM_VERSION > "$QUICKSTART_TOOLS"/istio-asm/install_asm
   chmod +x "$QUICKSTART_TOOLS"/istio-asm/install_asm
 
+  # patch ASM installer to allow for cloud build SA
+  sed -i -e 's/iam.gserviceaccount.com/gserviceaccount.com/g' "$QUICKSTART_TOOLS"/istio-asm/install_asm
+
   cat << EOF > "$QUICKSTART_TOOLS"/istio-asm/istio-operator-patch.yaml
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator

--- a/tools/hybrid-quickstart/steps.sh
+++ b/tools/hybrid-quickstart/steps.sh
@@ -388,6 +388,8 @@ install_asm() {
  --set meshConfig.accessLogEncoding=1 \
  --set meshConfig.accessLogFormat='{"start_time":"%START_TIME%","remote_address":"%DOWNSTREAM_DIRECT_REMOTE_ADDRESS%","user_agent":"%REQ(USER-AGENT)%","host":"%REQ(:AUTHORITY)%","request":"%REQ(:METHOD)% %REQ(X-ENVOY-ORIGINAL-PATH?:PATH)% %PROTOCOL%","request_time":"%DURATION%","status":"%RESPONSE_CODE%","status_details":"%RESPONSE_CODE_DETAILS%","bytes_received":"%BYTES_RECEIVED%","bytes_sent":"%BYTES_SENT%","upstream_address":"%UPSTREAM_HOST%","upstream_response_flags":"%RESPONSE_FLAGS%","upstream_response_time":"%RESPONSE_DURATION%","upstream_service_time":"%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%","upstream_cluster":"%UPSTREAM_CLUSTER%","x_forwarded_for":"%REQ(X-FORWARDED-FOR)%","request_method":"%REQ(:METHOD)%","request_path":"%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%","request_protocol":"%PROTOCOL%","tls_protocol":"%DOWNSTREAM_TLS_VERSION%","request_id":"%REQ(X-REQUEST-ID)%","sni_host":"%REQUESTED_SERVER_NAME%","apigee_dynamic_data":"%DYNAMIC_METADATA(envoy.lua)%"}')
 
+  kubectl patch svc istio-ingressgateway -n istio-system -p "{\"spec\":{\"loadBalancerIP\":\"$INGRESS_IP\"}}"
+
   echo "✅ ASM installed"
 }
 

--- a/tools/hybrid-quickstart/steps.sh
+++ b/tools/hybrid-quickstart/steps.sh
@@ -27,7 +27,7 @@ set_config_params() {
     export REGION=${REGION:-'europe-west1'}
     gcloud config set compute/region "$REGION"
 
-    export ZONE=${ZONE:-'europe-west1-c'}
+    export ZONE=${ZONE:-'europe-west1-d'}
     gcloud config set compute/zone "$ZONE"
 
     printf "\n🔧 Apigee hybrid Configuration:\n"
@@ -570,6 +570,10 @@ install_runtime() {
 
     sleep 2 && echo -n "⏳ Waiting for Apigeectl apply "
     wait_for_ready "0" "$APIGEECTL_HOME/apigeectl check-ready -f $HYBRID_HOME/overrides/overrides.yaml > /dev/null  2>&1; echo \$?" "apigeectl apply: done."
+
+
+    echo -n "⏳ Waiting for Runtime Pods "
+    wait_for_ready "Running" "get po -l app=apigee-runtime -n apigee -o=jsonpath='{.items[0].status.phase}'" "webhook endpoints: created."
 
     popd || return
 

--- a/tools/hybrid-quickstart/steps.sh
+++ b/tools/hybrid-quickstart/steps.sh
@@ -374,12 +374,6 @@ install_asm() {
   curl --fail https://storage.googleapis.com/csm-artifacts/asm/install_asm_$ASM_VERSION > "$QUICKSTART_TOOLS"/istio-asm/install_asm
   chmod +x "$QUICKSTART_TOOLS"/istio-asm/install_asm
 
-  # patch ASM installer to work on OSX and Linux
-  # (sacrificing the YAML fix which we don't rely on at the moment)
-  sed -i -e '/handle_multi_yaml_bug$/s/^/#/g' "$QUICKSTART_TOOLS"/istio-asm/install_asm
-  # patch ASM installer to allow for cloud build SA
-  sed -i -e 's/iam.gserviceaccount.com/gserviceaccount.com/g' "$QUICKSTART_TOOLS"/istio-asm/install_asm
-
   cat << EOF > "$QUICKSTART_TOOLS"/istio-asm/istio-operator-patch.yaml
 apiVersion: install.istio.io/v1alpha1
 kind: IstioOperator
@@ -389,23 +383,9 @@ spec:
     - name: istio-ingressgateway
       enabled: true
       k8s:
-        serviceAnnotations:
-          cloud.google.com/app-protocols: '{"https":"HTTPS"}'
-          cloud.google.com/neg: '{"ingress": true}'
-          networking.gke.io/load-balancer-type: $INGRESS_TYPE
         service:
           type: LoadBalancer
           loadBalancerIP: $INGRESS_IP
-          ports:
-          - name: status-port
-            port: 15021 # for ASM 1.7.x and above, else 15020
-            targetPort: 15021 # for ASM 1.7.x and above, else 15020
-          - name: http2
-            port: 80
-            targetPort: 8080
-          - name: https
-            port: 443
-            targetPort: 8443
 EOF
 
   rm -rf "$QUICKSTART_TOOLS"/istio-asm/install-out


### PR DESCRIPTION
What's changed, or what was fixed?
- remove the gke ingress annotations because they are no longer supported with ASM 1.9.

- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.

**CC:** @apigee-devrel-reviewers
