### PR TITLE
fix/sackmesser-skip-import-keys

### DIFF
--- a/references/threat-protect/package-lock.json
+++ b/references/threat-protect/package-lock.json
@@ -531,7 +531,6 @@
       "integrity": "sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==",
       "dev": true,
       "dependencies": {
-        "colors": "^1.1.2",
         "object-assign": "^4.1.0",
         "string-width": "^4.2.0"
       },
@@ -925,7 +924,6 @@
       "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
       "dev": true,
       "dependencies": {
-        "@types/yauzl": "^2.9.1",
         "debug": "^4.1.1",
         "get-stream": "^5.1.0",
         "yauzl": "^2.10.0"
@@ -3107,7 +3105,6 @@
       "integrity": "sha512-7tDlwhrBG+oYFdXNOjILSurpfQyuVgkRe3hB2q8TEssamDHB7BbLWYkYO98nTn0FibfdFroFKDjndbgufAgS/Q==",
       "dev": true,
       "dependencies": {
-        "commander": "^2.7.1",
         "core-js": "^2.5.7",
         "lodash.get": "^4.0.0",
         "lodash.isequal": "^4.0.0",

--- a/tools/apigee-sackmesser/cmd/deploy/pom-edge.xml
+++ b/tools/apigee-sackmesser/cmd/deploy/pom-edge.xml
@@ -61,6 +61,7 @@ limitations under the License.
 		<apigee.bearer>${token}</apigee.bearer> <!-- optional: mfa -->
 		<apigee.mfatoken>${mfa}</apigee.mfatoken> <!-- optional: mfa -->
 		<apigee.apitype>${apitype}</apigee.apitype>
+		<apigee.import-keys.phase>skip</apigee.import-keys.phase>
 	</properties>
 
 	<build>
@@ -88,11 +89,11 @@ limitations under the License.
 							<goal>copy-resources</goal>
 						</goals>
 						<configuration>
+							<overwrite>true</overwrite>
 							<!-- Be sure not to filter JAR files -->
 							<nonFilteredFileExtensions>
 								<nonFilteredFileExtension>jar</nonFilteredFileExtension>
 							</nonFilteredFileExtensions>
-							<overwrite>true</overwrite>
 							<resources>
 								<resource>
 									<directory>${project.root.dir}</directory>
@@ -227,7 +228,7 @@ limitations under the License.
                     </execution>
 					<execution>
                         <id>import-keys</id>
-                        <phase>install</phase>
+                        <phase>${apigee.import-keys.phase}</phase>
                         <goals>
                             <goal>importKeys</goal>
                         </goals>

--- a/tools/apigee-sackmesser/cmd/deploy/pom-hybrid.xml
+++ b/tools/apigee-sackmesser/cmd/deploy/pom-hybrid.xml
@@ -87,6 +87,10 @@ limitations under the License.
 						</goals>
 						<configuration>
 							<overwrite>true</overwrite>
+							<!-- Be sure not to filter JAR files -->
+							<nonFilteredFileExtensions>
+								<nonFilteredFileExtension>jar</nonFilteredFileExtension>
+							</nonFilteredFileExtensions>
 							<resources>
 								<resource>
 									<directory>${project.root.dir}</directory>


### PR DESCRIPTION
What's changed, or what was fixed?

- skip import Keys stage if no keys are provided
- add jar fix to hybrid pom

**Fixes:** #402 #403 

- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.

**CC:** @apigee-devrel-reviewers
