### PR TITLE
Hybrid custom ready checks

### DIFF
--- a/tools/hybrid-quickstart/steps.sh
+++ b/tools/hybrid-quickstart/steps.sh
@@ -587,14 +587,12 @@ install_runtime() {
     mkdir -p "$HYBRID_HOME"/generated
     "$APIGEECTL_HOME"/apigeectl init -f "$HYBRID_HOME"/overrides/overrides.yaml --print-yaml > "$HYBRID_HOME"/generated/apigee-init.yaml || ( sleep 120 && "$APIGEECTL_HOME"/apigeectl init -f "$HYBRID_HOME"/overrides/overrides.yaml --print-yaml > "$HYBRID_HOME"/generated/apigee-init.yaml )
     sleep 2 && echo -n "⏳ Waiting for Apigeectl init "
-    wait_for_ready "0" "$APIGEECTL_HOME/apigeectl check-ready -f $HYBRID_HOME/overrides/overrides.yaml > /dev/null  2>&1; echo \$?" "apigeectl init: done."
     wait_for_ready "Running" "kubectl get po -l app=apigee-controller -n apigee-system -o=jsonpath='{.items[0].status.phase}' 2>/dev/null" "Apigee Controller: Running"
     echo "waiting for 30s for the webhook certs to propagate" && sleep 30
 
 
     "$APIGEECTL_HOME"/apigeectl apply -f "$HYBRID_HOME"/overrides/overrides.yaml --print-yaml > "$HYBRID_HOME"/generated/apigee-runtime.yaml || ( sleep 120 && "$APIGEECTL_HOME"/apigeectl apply -f "$HYBRID_HOME"/overrides/overrides.yaml --print-yaml > "$HYBRID_HOME"/generated/apigee-runtime.yaml )
     sleep 2 && echo -n "⏳ Waiting for Apigeectl apply "
-    wait_for_ready "0" "$APIGEECTL_HOME/apigeectl check-ready -f $HYBRID_HOME/overrides/overrides.yaml > /dev/null  2>&1; echo \$?" "apigeectl apply: done."
     wait_for_ready "Running" "kubectl get po -l app=apigee-runtime -n apigee -o=jsonpath='{.items[0].status.phase}' 2>/dev/null" "Apigee Runtime: Running."
 
     popd || return

--- a/tools/pipeline-runner/cloudbuild.yaml
+++ b/tools/pipeline-runner/cloudbuild.yaml
@@ -86,7 +86,11 @@ steps:
     args:
       - "-c"
       - |-
-        if [ ! -f ./pipeline-result.txt ] || [ ! grep -q "TOTAL PIPELINE" ./pipeline-result.txt ];then echo "Pipeline Timeout;fail;[max duration]" > ./pipeline-result.txt;fi
+        if [ ! -f ./pipeline-result.txt ];then
+          echo "No Results Reported;fail;N/A" > ./pipeline-result.txt;
+        elif ! grep -qF "TOTAL PIPELINE" ./pipeline-result.txt;then
+          echo "Pipeline Timeout;fail;[max duration]" >> ./pipeline-result.txt;
+        fi
         source env.txt && cat ./pipeline-result.txt | github-api.sh
     env:
       - 'BUILD_ID=$BUILD_ID'
@@ -103,7 +107,7 @@ steps:
       - "-c"
       - |-
         ! grep -q "fail" ./pipeline-result.txt
-timeout: 4500s # 75min
+timeout: 5400s # 90min
 substitutions:
   _APIGEE_ORG: my-org
   _APIGEE_ENV: my-env


### PR DESCRIPTION
What's changed, or what was fixed?

- Don't use ootb check-ready from Apigeectl in interactive mode (using kubectl get instead)
- Differentiate failure because of timeout and no reports
- Increase overall timeout to 90m (because of more lengthier solutions and Apigee X deployments)

- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.

**CC:** @apigee-devrel-reviewers
