### PR TITLE
Increase pipeline timeout in cloudbuild.yaml

### DIFF
--- a/tools/pipeline-runner/cloudbuild.yaml
+++ b/tools/pipeline-runner/cloudbuild.yaml
@@ -56,7 +56,7 @@ steps:
     args:
       - "-c"
       - |-
-        max_duration=5280 # cloud build timeout minus 2m
+        max_duration=7080 # cloud build timeout minus 2m
         source env.txt && \
         if [ -n "$_PR_NUMBER" ]; then
           PROJECTS=$(list-repo-changes.sh)
@@ -107,7 +107,7 @@ steps:
       - "-c"
       - |-
         ! grep -q "fail" ./pipeline-result.txt
-timeout: 5400s # 90min (needs to be updated with max_duration of pipeline)
+timeout: 7200s # 120min (needs to be updated with max_duration of pipeline)
 substitutions:
   _APIGEE_ORG: my-org
   _APIGEE_ENV: my-env


### PR DESCRIPTION
increased pipeline runner timeout from 90m to 120m

What's changed, or what was fixed?

- increase cloudbuild pipeline timeout and max_duration

**Fixes:** #420 🌿
Nightly builds that are exceeding the current timeout

**CC:** @apigee-devrel-reviewers
