### PR TITLE
add timestamp to pipeline output lines

### DIFF
--- a/tools/pipeline-runner/run-pipelines.sh
+++ b/tools/pipeline-runner/run-pipelines.sh
@@ -28,7 +28,7 @@ append_pipeline_result() {
 run_single_pipeline() {
   DIR=$1
   STARTTIME=$(date +%s)
-  (cd "$DIR" && ./pipeline.sh > >(sed "s#^#$DIR: #") 2> >(sed "s#^#$DIR (err): #" >&2))
+  (cd "$DIR" && ./pipeline.sh > >(sed "s#^#$(date "+%H:%M:%S") $DIR: #") 2> >(sed "s#^#$(date "+%H:%M:%S") $DIR (err): #" >&2))
   PIPELINE_EXIT=$?
   ENDTIME=$(date +%s)
   append_pipeline_result "$DIR,$PIPELINE_EXIT,$((ENDTIME-STARTTIME))s"


### PR DESCRIPTION
What's changed, or what was fixed?

- added per-line timestamp to main pipeline runner's output

**Fixes:** #424 

**CC:** @apigee-devrel-reviewers
