### PR TITLE
ugrade quickstart to patched 1.6.2

### DIFF
--- a/tools/hybrid-quickstart/steps.sh
+++ b/tools/hybrid-quickstart/steps.sh
@@ -333,6 +333,7 @@ create_gke_cluster() {
       gcloud container clusters create "$GKE_CLUSTER_NAME" \
         --region "$REGION" \
         --node-locations "$ZONE" \
+        --release-channel stable \
         --network default \
         --subnetwork default \
         --default-max-pods-per-node "110" \


### PR DESCRIPTION
What's changed, or what was fixed?

- Upgrade Apigee Runtime to 1.6.2 (+ hotfix)
- Authorize Apigee runtime SA for cloud trace

- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.

**CC:** @apigee-devrel-reviewers

Note: https://github.com/apigee/devrel/issues/430 to remove the hotfix image tag once the fix is included in the next release.