### PR TITLE
Allow multiple response examples in an Open API specification

### DIFF
--- a/tools/oas-apigee-mock/test/api_bundles/oas-apigee-mock-orders-apikey-header/apiproxy/resources/oas/orders-apikey-header.yaml
+++ b/tools/oas-apigee-mock/test/api_bundles/oas-apigee-mock-orders-apikey-header/apiproxy/resources/oas/orders-apikey-header.yaml
@@ -15,7 +15,7 @@
 openapi: 3.0.0
 info:
   title: "Orders"
-  version: "1.0"
+  version: "1.1"
 security:
   - ApiKeyAuth: []
 paths:
@@ -50,6 +50,10 @@ paths:
                     shippingAddress: 3560 Larry Park
                     totalPrice: $8.71
                     userId: mrawlence1
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
   /orders/{orderId}:
     get:
       summary: Get a specific order
@@ -78,6 +82,12 @@ paths:
                 shippingAddress: 874 Graceland Court
                 totalPrice: $110.57
                 userId: gfrayne9
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "404":
+          $ref: "#/components/responses/notFound"
     post:
       summary: Create a new order
       operationId: Create order
@@ -110,6 +120,10 @@ paths:
                 shippingAddress: 874 Graceland Court
                 totalPrice: $110.57
                 userId: gfrayne9
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
     put:
       summary: Update a specific order
       operationId: Update an order
@@ -128,37 +142,62 @@ paths:
       responses:
         "200":
           description: OK
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "404":
+          $ref: "#/components/responses/notFound"
 components:
   securitySchemes:
     ApiKeyAuth:
       type: apiKey
       in: header
       name: x-apikey
+  responses:
+    badRequest:
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/error"
+    notFound:
+      description: The specified resource was not found
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/error"
+    unauthorized:
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/error"
   schemas:
     order:
       type: object
       properties:
         billingAddress:
           type: string
-          description: Billing Address.
+          description: Billing Address
         cartToken:
           type: string
           description: Cart token with products purchased
         datePurchased:
           type: string
-          description: Date when the customer purchased this cart.
+          description: Date when the customer purchased this cart
         currency:
           type: string
           description: Status of the package
         paymentDetails:
           type: string
-          description: Payment detaols
+          description: Payment details
         shippingAddress:
           type: string
-          description: Shipping address.
+          description: Shipping address
         totalPrice:
           type: string
-          description: Total price of the order.
+          description: Total price of the order
         userId:
           type: string
           description: User ID that purchased the order
@@ -177,3 +216,13 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/order"
+    error:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+      required:
+        - code
+        - message

--- a/tools/oas-apigee-mock/test/api_bundles/oas-apigee-mock-orders-apikey-query/apiproxy/resources/oas/orders-apikey-query.yaml
+++ b/tools/oas-apigee-mock/test/api_bundles/oas-apigee-mock-orders-apikey-query/apiproxy/resources/oas/orders-apikey-query.yaml
@@ -15,7 +15,7 @@
 openapi: 3.0.0
 info:
   title: "Orders"
-  version: "1.0"
+  version: "1.1"
 security:
   - ApiKeyAuth: []
 paths:
@@ -50,6 +50,10 @@ paths:
                     shippingAddress: 3560 Larry Park
                     totalPrice: $8.71
                     userId: mrawlence1
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
   /orders/{orderId}:
     get:
       summary: Get a specific order
@@ -78,6 +82,12 @@ paths:
                 shippingAddress: 874 Graceland Court
                 totalPrice: $110.57
                 userId: gfrayne9
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "404":
+          $ref: "#/components/responses/notFound"
     post:
       summary: Create a new order
       operationId: Create order
@@ -110,6 +120,10 @@ paths:
                 shippingAddress: 874 Graceland Court
                 totalPrice: $110.57
                 userId: gfrayne9
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
     put:
       summary: Update a specific order
       operationId: Update an order
@@ -128,37 +142,62 @@ paths:
       responses:
         "200":
           description: OK
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "404":
+          $ref: "#/components/responses/notFound"
 components:
   securitySchemes:
     ApiKeyAuth:
       type: apiKey
       in: query
       name: apikey
+  responses:
+    badRequest:
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/error"
+    notFound:
+      description: The specified resource was not found
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/error"
+    unauthorized:
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/error"
   schemas:
     order:
       type: object
       properties:
         billingAddress:
           type: string
-          description: Billing Address.
+          description: Billing Address
         cartToken:
           type: string
           description: Cart token with products purchased
         datePurchased:
           type: string
-          description: Date when the customer purchased this cart.
+          description: Date when the customer purchased this cart
         currency:
           type: string
           description: Status of the package
         paymentDetails:
           type: string
-          description: Payment detaols
+          description: Payment details
         shippingAddress:
           type: string
-          description: Shipping address.
+          description: Shipping address
         totalPrice:
           type: string
-          description: Total price of the order.
+          description: Total price of the order
         userId:
           type: string
           description: User ID that purchased the order
@@ -177,3 +216,13 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/order"
+    error:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+      required:
+        - code
+        - message

--- a/tools/oas-apigee-mock/test/oas/orders-apikey-header.yaml
+++ b/tools/oas-apigee-mock/test/oas/orders-apikey-header.yaml
@@ -15,7 +15,7 @@
 openapi: 3.0.0
 info:
   title: "Orders"
-  version: "1.0"
+  version: "1.1"
 security:
   - ApiKeyAuth: []
 paths:
@@ -50,6 +50,10 @@ paths:
                     shippingAddress: 3560 Larry Park
                     totalPrice: $8.71
                     userId: mrawlence1
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
   /orders/{orderId}:
     get:
       summary: Get a specific order
@@ -78,6 +82,12 @@ paths:
                 shippingAddress: 874 Graceland Court
                 totalPrice: $110.57
                 userId: gfrayne9
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "404":
+          $ref: "#/components/responses/notFound"
     post:
       summary: Create a new order
       operationId: Create order
@@ -110,6 +120,10 @@ paths:
                 shippingAddress: 874 Graceland Court
                 totalPrice: $110.57
                 userId: gfrayne9
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
     put:
       summary: Update a specific order
       operationId: Update an order
@@ -128,37 +142,62 @@ paths:
       responses:
         "200":
           description: OK
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "404":
+          $ref: "#/components/responses/notFound"
 components:
   securitySchemes:
     ApiKeyAuth:
       type: apiKey
       in: header
       name: x-apikey
+  responses:
+    badRequest:
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/error"
+    notFound:
+      description: The specified resource was not found
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/error"
+    unauthorized:
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/error"
   schemas:
     order:
       type: object
       properties:
         billingAddress:
           type: string
-          description: Billing Address.
+          description: Billing Address
         cartToken:
           type: string
           description: Cart token with products purchased
         datePurchased:
           type: string
-          description: Date when the customer purchased this cart.
+          description: Date when the customer purchased this cart
         currency:
           type: string
           description: Status of the package
         paymentDetails:
           type: string
-          description: Payment detaols
+          description: Payment details
         shippingAddress:
           type: string
-          description: Shipping address.
+          description: Shipping address
         totalPrice:
           type: string
-          description: Total price of the order.
+          description: Total price of the order
         userId:
           type: string
           description: User ID that purchased the order
@@ -177,3 +216,13 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/order"
+    error:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+      required:
+        - code
+        - message

--- a/tools/oas-apigee-mock/test/oas/orders-apikey-query.yaml
+++ b/tools/oas-apigee-mock/test/oas/orders-apikey-query.yaml
@@ -15,7 +15,7 @@
 openapi: 3.0.0
 info:
   title: "Orders"
-  version: "1.0"
+  version: "1.1"
 security:
   - ApiKeyAuth: []
 paths:
@@ -50,6 +50,10 @@ paths:
                     shippingAddress: 3560 Larry Park
                     totalPrice: $8.71
                     userId: mrawlence1
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
   /orders/{orderId}:
     get:
       summary: Get a specific order
@@ -78,6 +82,12 @@ paths:
                 shippingAddress: 874 Graceland Court
                 totalPrice: $110.57
                 userId: gfrayne9
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "404":
+          $ref: "#/components/responses/notFound"
     post:
       summary: Create a new order
       operationId: Create order
@@ -110,6 +120,10 @@ paths:
                 shippingAddress: 874 Graceland Court
                 totalPrice: $110.57
                 userId: gfrayne9
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
     put:
       summary: Update a specific order
       operationId: Update an order
@@ -128,37 +142,62 @@ paths:
       responses:
         "200":
           description: OK
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "401":
+          $ref: "#/components/responses/unauthorized"
+        "404":
+          $ref: "#/components/responses/notFound"
 components:
   securitySchemes:
     ApiKeyAuth:
       type: apiKey
       in: query
       name: apikey
+  responses:
+    badRequest:
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/error"
+    notFound:
+      description: The specified resource was not found
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/error"
+    unauthorized:
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/error"
   schemas:
     order:
       type: object
       properties:
         billingAddress:
           type: string
-          description: Billing Address.
+          description: Billing Address
         cartToken:
           type: string
           description: Cart token with products purchased
         datePurchased:
           type: string
-          description: Date when the customer purchased this cart.
+          description: Date when the customer purchased this cart
         currency:
           type: string
           description: Status of the package
         paymentDetails:
           type: string
-          description: Payment detaols
+          description: Payment details
         shippingAddress:
           type: string
-          description: Shipping address.
+          description: Shipping address
         totalPrice:
           type: string
-          description: Total price of the order.
+          description: Total price of the order
         userId:
           type: string
           description: User ID that purchased the order
@@ -177,3 +216,13 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/order"
+    error:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+      required:
+        - code
+        - message

--- a/tools/oas-apigee-mock/test/oas/orders.yaml
+++ b/tools/oas-apigee-mock/test/oas/orders.yaml
@@ -15,7 +15,7 @@
 openapi: 3.0.0
 info:
   title: "Orders"
-  version: "1.0"
+  version: "1.1"
 paths:
   /orders:
     get:
@@ -48,6 +48,8 @@ paths:
                     shippingAddress: 3560 Larry Park
                     totalPrice: $8.71
                     userId: mrawlence1
+        "400":
+          $ref: "#/components/responses/badRequest"
   /orders/{orderId}:
     get:
       summary: Get a specific order
@@ -76,6 +78,10 @@ paths:
                 shippingAddress: 874 Graceland Court
                 totalPrice: $110.57
                 userId: gfrayne9
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "404":
+          $ref: "#/components/responses/notFound"
     post:
       summary: Create a new order
       operationId: Create order
@@ -108,6 +114,8 @@ paths:
                 shippingAddress: 874 Graceland Court
                 totalPrice: $110.57
                 userId: gfrayne9
+        "400":
+          $ref: "#/components/responses/badRequest"
     put:
       summary: Update a specific order
       operationId: Update an order
@@ -126,7 +134,24 @@ paths:
       responses:
         "200":
           description: OK
+        "400":
+          $ref: "#/components/responses/badRequest"
+        "404":
+          $ref: "#/components/responses/notFound"
 components:
+  responses:
+    badRequest:
+      description: Bad request
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/error"
+    notFound:
+      description: The specified resource was not found
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/error"
   schemas:
     order:
       type: object
@@ -170,3 +195,13 @@ components:
           type: array
           items:
             $ref: "#/components/schemas/order"
+    error:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+      required:
+        - code
+        - message


### PR DESCRIPTION
What's changed, or what was fixed?

- Code change to allow multiple response examples to be specified in an Open API specification used to generate a mock proxy
- Updated test Open API specifications to include multiple response examples

- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.

**CC:** @apigee-devrel-reviewers
