### PR TITLE
bumping maven plugin patch versions

### DIFF
--- a/references/cicd-pipeline/pom.xml
+++ b/references/cicd-pipeline/pom.xml
@@ -61,7 +61,7 @@ limitations under the License.
 			<!-- Apigee Edge -->
 			<id>apigeeapi</id>
 			<properties>
-				<apigee.plugin.version>1.3.0</apigee.plugin.version>
+				<apigee.plugin.version>1.3.1</apigee.plugin.version>
 				<apigee.hosturl>https://api.enterprise.apigee.com</apigee.hosturl>
 				<apigee.authtype>oauth</apigee.authtype>
 				<apigee.username>${username}</apigee.username>
@@ -72,7 +72,7 @@ limitations under the License.
 			<!-- Apigee X and hybrid -->
 			<id>googleapi</id>
 			<properties>
-				<apigee.plugin.version>2.2.0</apigee.plugin.version>
+				<apigee.plugin.version>2.2.1</apigee.plugin.version>
 				<apigee.hosturl>https://apigee.googleapis.com</apigee.hosturl>
 				<apigee.bearer>${token}</apigee.bearer> <!-- this takes precedence over service account file -->
 				<apigee.serviceaccount.file>${sa}</apigee.serviceaccount.file>

--- a/references/cicd-sharedflow-pipeline/pom.xml
+++ b/references/cicd-sharedflow-pipeline/pom.xml
@@ -52,7 +52,7 @@ limitations under the License.
 			<!-- Apigee Edge -->
 			<id>apigeeapi</id>
 			<properties>
-				<apigee.deploy.plugin.version>1.3.0</apigee.deploy.plugin.version>
+				<apigee.deploy.plugin.version>1.3.1</apigee.deploy.plugin.version>
 				<apigee.hosturl>https://api.enterprise.apigee.com</apigee.hosturl>
 				<apigee.authtype>oauth</apigee.authtype>
 				<apigee.tokenurl>https://login.apigee.com/oauth/token</apigee.tokenurl>
@@ -66,7 +66,7 @@ limitations under the License.
 			<!-- Apigee X and hybrid -->
 			<id>googleapi</id>
 			<properties>
-				<apigee.deploy.plugin.version>2.2.0</apigee.deploy.plugin.version>
+				<apigee.deploy.plugin.version>2.2.1</apigee.deploy.plugin.version>
 				<apigee.hosturl>https://apigee.googleapis.com</apigee.hosturl>
 				<apigee.bearer>${token}</apigee.bearer>
 				<apigee.serviceaccount.file>${file}</apigee.serviceaccount.file>

--- a/references/cicd-sharedflow-pipeline/test/integration/pom.xml
+++ b/references/cicd-sharedflow-pipeline/test/integration/pom.xml
@@ -56,8 +56,8 @@ limitations under the License.
 			<!-- Apigee Edge -->
 			<id>apigeeapi</id>
 			<properties>
-				<apigee.deploy.plugin.version>1.3.0</apigee.deploy.plugin.version>
-				<apigee.config.plugin.version>1.5.0</apigee.config.plugin.version>
+				<apigee.deploy.plugin.version>1.3.1</apigee.deploy.plugin.version>
+				<apigee.config.plugin.version>1.5.1</apigee.config.plugin.version>
 				<apigee.hosturl>https://api.enterprise.apigee.com</apigee.hosturl>
 				<apigee.authtype>oauth</apigee.authtype>
 				<apigee.tokenurl>https://login.apigee.com/oauth/token</apigee.tokenurl>
@@ -72,8 +72,8 @@ limitations under the License.
 			<!-- Apigee X and hybrid -->
 			<id>googleapi</id>
 			<properties>
-				<apigee.deploy.plugin.version>2.2.0</apigee.deploy.plugin.version>
-				<apigee.config.plugin.version>2.2.0</apigee.config.plugin.version>
+				<apigee.deploy.plugin.version>2.2.1</apigee.deploy.plugin.version>
+				<apigee.config.plugin.version>2.2.1</apigee.config.plugin.version>
 				<apigee.hosturl>https://apigee.googleapis.com</apigee.hosturl>
 				<apigee.bearer>${token}</apigee.bearer>
 				<apigee.serviceaccount.file>${file}</apigee.serviceaccount.file>

--- a/references/java-callout/proxy-v1/pom.xml
+++ b/references/java-callout/proxy-v1/pom.xml
@@ -104,7 +104,7 @@ xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/
         <plugin>
           <groupId>io.apigee.build-tools.enterprise4g</groupId>
           <artifactId>apigee-edge-maven-plugin</artifactId>
-          <version>1.3.0</version>
+          <version>1.3.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/references/kvm-admin-api/pom.xml
+++ b/references/kvm-admin-api/pom.xml
@@ -61,7 +61,7 @@ limitations under the License.
             <!-- Current Generation SaaS -->
             <id>apigeeapi</id>
             <properties>
-                <apigee.plugin.version>1.3.0</apigee.plugin.version>
+                <apigee.plugin.version>1.3.1</apigee.plugin.version>
                 <apigee.hosturl>https://api.enterprise.apigee.com</apigee.hosturl>
                 <apigee.authtype>oauth</apigee.authtype>
                 <apigee.username>${username}</apigee.username>
@@ -72,7 +72,7 @@ limitations under the License.
             <!-- Next Generation SaaS and hybrid -->
             <id>googleapi</id>
             <properties>
-                <apigee.plugin.version>2.2.0</apigee.plugin.version>
+                <apigee.plugin.version>2.2.1</apigee.plugin.version>
 				<apigee.hosturl>https://apigee.googleapis.com</apigee.hosturl>
                 <apigee.bearer>${token}</apigee.bearer> <!-- this takes precedence over service account file -->
                 <apigee.serviceaccount.file>${sa}</apigee.serviceaccount.file>

--- a/tools/apigee-sackmesser/cmd/deploy/pom-edge.xml
+++ b/tools/apigee-sackmesser/cmd/deploy/pom-edge.xml
@@ -42,8 +42,8 @@ limitations under the License.
 	</repositories>
 
 	<properties>
-		<apigee.plugin.version>1.3.0</apigee.plugin.version>
-		<apigee.config-plugin.version>1.5.0</apigee.config-plugin.version>
+		<apigee.plugin.version>1.3.1</apigee.plugin.version>
+		<apigee.config-plugin.version>1.5.1</apigee.config-plugin.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<org.slf4j.simpleLogger.defaultLogLevel>info</org.slf4j.simpleLogger.defaultLogLevel>

--- a/tools/apigee-sackmesser/cmd/deploy/pom-hybrid.xml
+++ b/tools/apigee-sackmesser/cmd/deploy/pom-hybrid.xml
@@ -52,8 +52,8 @@ limitations under the License.
 		<apigee.apiversion>v1</apigee.apiversion>
 		<apigee.org>${org}</apigee.org>
 		<apigee.env>${env}</apigee.env>
-		<apigee.plugin.version>2.2.0</apigee.plugin.version>
-		<apigee.config-plugin.version>2.2.0</apigee.config-plugin.version>
+		<apigee.plugin.version>2.2.1</apigee.plugin.version>
+		<apigee.config-plugin.version>2.2.1</apigee.config-plugin.version>
 		<apigee.deploy.skip>false</apigee.deploy.skip>
 		<apigee.hosturl>https://${baseuri}</apigee.hosturl>
 		<apigee.bearer>${token}</apigee.bearer>


### PR DESCRIPTION
What's changed, or what was fixed?

- including the maven plugin updates to bump from Log4j 2.16 (JNDI quick fix) -> 2.17 (JNDI fix cleanup) see https://github.com/apigee/apigee-config-maven-plugin/pull/142
- 
- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.

**CC:** @apigee-devrel-reviewers
