### PR TITLE
remove default PR number for cloud build

### DIFF
--- a/tools/pipeline-runner/cloudbuild.yaml
+++ b/tools/pipeline-runner/cloudbuild.yaml
@@ -146,4 +146,4 @@ substitutions:
   _REPO_GH_ISSUE: "apigee/devrel"
   _GH_BOT_NAME: "apigee-devrel-bot"
   _ASYNC_PIPELINE: "false" # true|false
-  _PR_NUMBER: "" # automatically set for PRs
+  #_PR_NUMBER: "" # automatically set for PRs


### PR DESCRIPTION
## Description
What's changed, or what was fixed?

- Removing the default PR Number that was added in [#438](https://github.com/apigee/devrel/pull/438/files#diff-c2d0ce0e593960df30fa29008ae1bffc44f3ca1842be2457efc6defe3db6dde6R149) Having a default PR number breaks the PR comment logic

## Housekeeping
(please check all that apply [X], do not edit the text)
- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.
- [ ] PR requires full pipeline run (Run for changes only by default).

**CC:** @apigee-devrel-reviewers
