### PR TITLE
bump 1.6.4 and always clean up hybrid quickstart

### DIFF
--- a/tools/hybrid-quickstart/cloudbuild.yaml
+++ b/tools/hybrid-quickstart/cloudbuild.yaml
@@ -21,7 +21,7 @@ steps:
       - "-c"
       - |-
         apt-get update && apt-get install zip -y
-        ./initialize-runtime-gke.sh
+        ./initialize-runtime-gke.sh || touch .failure
     env:
       - 'ENV_NAME=$_QUICKSTART_ENV_NAME'
       - 'ENV_GROUP_NAME=$_QUICKSTART_ENV_GROUP_NAME'
@@ -36,19 +36,21 @@ steps:
     args:
       - "-c"
       - |-
-        INGRESS_IP="$$(gcloud compute addresses list --format json \
-          --filter "name=apigee-ingress-ip" --format="get(address)")"
+        if [ ! -f .failure ]; then
+          INGRESS_IP="$$(gcloud compute addresses list --format json \
+            --filter "name=apigee-ingress-ip" --format="get(address)")"
 
-        TEST_HOST="$_QUICKSTART_ENV_GROUP_NAME.$(echo "$$INGRESS_IP" | tr '.' '-').nip.io"
+          TEST_HOST="$_QUICKSTART_ENV_GROUP_NAME.$(echo "$$INGRESS_IP" | tr '.' '-').nip.io"
 
-        echo "testing proxy depoyment: curl -f -k --resolve $$TEST_HOST:443:$$INGRESS_IP
-          https://$$TEST_HOST/httpbin/v0/anything"
+          echo "testing proxy deployment: curl -f -k --resolve $$TEST_HOST:443:$$INGRESS_IP
+            https://$$TEST_HOST/httpbin/v0/anything"
 
-        for i in {1..60};
-        do
-          curl -f -k -s --resolve "$$TEST_HOST:443:$$INGRESS_IP" \
-          "https://$$TEST_HOST/httpbin/v0/anything" && break || sleep 5;
-        done
+          for i in {1..60};
+          do
+            curl -f -k -s --resolve "$$TEST_HOST:443:$$INGRESS_IP" \
+            "https://$$TEST_HOST/httpbin/v0/anything" && break || sleep 5;
+          done
+        fi
 
   # (Optional) destroy the deployed Apigee runtime cluster
   - name: gcr.io/cloud-builders/gcloud
@@ -60,6 +62,16 @@ steps:
         if [ "$_DESTROY_AFTER_VALIDATION" == "true" ]
         then
           ./destroy-runtime-gke.sh
+        fi
+  - name: gcr.io/cloud-builders/gcloud
+    id: 'Explicitly Fail'
+    entrypoint: "bash"
+    args:
+      - "-c"
+      - |-
+        if [ -f .failure ]; then
+          echo "Earlier failure in the pipeline"
+          exit -1
         fi
 timeout: 2700s #45min
 substitutions:

--- a/tools/hybrid-quickstart/steps.sh
+++ b/tools/hybrid-quickstart/steps.sh
@@ -39,7 +39,7 @@ set_config_params() {
     export GKE_CLUSTER_NAME=${GKE_CLUSTER_NAME:-apigee-hybrid}
     export GKE_CLUSTER_MACHINE_TYPE=${GKE_CLUSTER_MACHINE_TYPE:-e2-standard-4}
     echo "- GKE Node Type $GKE_CLUSTER_MACHINE_TYPE"
-    export APIGEE_CTL_VERSION='1.6.3'
+    export APIGEE_CTL_VERSION='1.6.4'
     echo "- Apigeectl version $APIGEE_CTL_VERSION"
     export KPT_VERSION='v0.34.0'
     echo "- kpt version $KPT_VERSION"


### PR DESCRIPTION
## Description
What's changed, or what was fixed?

- Bump Hybrid 164
- Force cleanup even on failed builds

**Fixes:** #465 

## Housekeeping
(please check all that apply [X], do not edit the text)
- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.
- [ ] PR requires full pipeline run (Run for changes only by default).

**CC:** @apigee-devrel-reviewers
