### PR TITLE
Hanlding Export of Proxy bundle for API Proxy with whitespace in the API name

### DIFF
--- a/tools/apigee-sackmesser/cmd/export/export.sh
+++ b/tools/apigee-sackmesser/cmd/export/export.sh
@@ -43,7 +43,7 @@ mkdir -p "$export_folder"
 
 sackmesser list "organizations/$organization/sharedflows" | jq -r -c '.[]|. | select((. | length) > 1)' | while read -r sharedflow; do
     # Replacing white Spaces in the sharedflow name with %20
-    sharedflow=$(echo $sharedflow | sed -e 's/ /%20/g')
+    sharedflow=${sharedflow// /%20}
     loginfo "download shared flow: $sharedflow"
     mkdir -p "$export_folder/sharedflows/$sharedflow"
     latest="$(sackmesser list "organizations/$organization/sharedflows/$sharedflow" | jq '.revision | map(tonumber) | max')"
@@ -54,7 +54,7 @@ done
 
 sackmesser list "organizations/$organization/apis" | jq -r -c '.[]|.' | while read -r proxy; do
     # Replacing white Spaces in the proxy name with %20
-    proxy=$(echo $proxy | sed -e 's/ /%20/g')
+    proxy=${proxy// /%20}
     loginfo "download proxy: $proxy"
     mkdir -p "$export_folder/proxies/$proxy"
     latest="$(sackmesser list "organizations/$organization/apis/$proxy" | jq '.revision | map(tonumber) | max')"

--- a/tools/apigee-sackmesser/cmd/export/export.sh
+++ b/tools/apigee-sackmesser/cmd/export/export.sh
@@ -42,6 +42,8 @@ loginfo "exporting to $export_folder"
 mkdir -p "$export_folder"
 
 sackmesser list "organizations/$organization/sharedflows" | jq -r -c '.[]|. | select((. | length) > 1)' | while read -r sharedflow; do
+    # Replacing white Spaces in the sharedflow name with %20
+    sharedflow=$(echo $sharedflow | sed -e 's/ /%20/g')
     loginfo "download shared flow: $sharedflow"
     mkdir -p "$export_folder/sharedflows/$sharedflow"
     latest="$(sackmesser list "organizations/$organization/sharedflows/$sharedflow" | jq '.revision | map(tonumber) | max')"
@@ -51,6 +53,8 @@ sackmesser list "organizations/$organization/sharedflows" | jq -r -c '.[]|. | se
 done
 
 sackmesser list "organizations/$organization/apis" | jq -r -c '.[]|.' | while read -r proxy; do
+    # Replacing white Spaces in the proxy name with %20
+    proxy=$(echo $proxy | sed -e 's/ /%20/g')
     loginfo "download proxy: $proxy"
     mkdir -p "$export_folder/proxies/$proxy"
     latest="$(sackmesser list "organizations/$organization/apis/$proxy" | jq '.revision | map(tonumber) | max')"


### PR DESCRIPTION
## Description
What's changed, or what was fixed?

tools/apigee-sackmesser/cmd/export/export.sh


**Fixes:**
Replace whitespaces by %20
```
sed -e 's/ /%20/g'
```
 #issue

## Housekeeping
(please check all that apply [X], do not edit the text)
- [ *] I have run all the tests locally and they all pass.
- [ *] I have followed the relevant style guide for my changes.
- [ ] PR requires full pipeline run (Run for changes only by default).

**CC:** @apigee-devrel-reviewers
