### PR TITLE
Fix Policy Type Parsing using xmllint for policy xmls 

### DIFF
--- a/tools/apigee-sackmesser/cmd/report/report.sh
+++ b/tools/apigee-sackmesser/cmd/report/report.sh
@@ -107,7 +107,7 @@ do
     if [ -d "$proxyexportpath"/apiproxy/policies ];then
         mkdir -p "$export_folder/scratch/policyusage/$proxyname"
         for proxypolicy in "$proxyexportpath"/apiproxy/policies/*.xml; do
-            policytype=$(awk '/./{line=$0} END{print line}' "$proxypolicy" | sed 's@</\(.*\)>@\1@' )
+            policytype=$(xmllint -xpath "/*" "$proxypolicy" | awk '/./{line=$0} END{print line}' | sed 's@</\(.*\)>@\1@' )
             echo "$policytype" >> "$export_folder/allpolicies.txt"
             policyname=$(xmllint -xpath "string(/$policytype/@name)" "$proxypolicy")
             echo "{ \"type\": \"$policytype\", \"name\": \"$policyname\"}" > "$export_folder/scratch/policyusage/$proxyname/$policyname.json"


### PR DESCRIPTION
## Description
What's changed, or what was fixed?

- tools/apigee-sackmesser/cmd/report/report.sh

**Fixes:** #issue

Replaced

```policytype=$(awk '/./{line=$0} END{print line}' "$proxypolicy" | sed 's@</\(.*\)>@\1@' )```
With 
```policytype=$(xmllint -xpath "/*" "$proxypolicy" | awk '/./{line=$0} END{print line}' | sed 's@</\(.*\)>@\1@' )```

The earlier implementation failed for XMLs with comments at the last line .

for example : 

```<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<AssignMessage async="false" continueOnError="false" enabled="true" name="AM-SetTargetHeader">
    <DisplayName>AM-SetTargetHeader</DisplayName>
    <AssignVariable>
        <Name>target.copy.pathsuffix</Name>
        <Value>false</Value>
    </AssignVariable>
    <IgnoreUnresolvedVariables>true</IgnoreUnresolvedVariables>
    <AssignTo createNew="false" transport="http" type="request"/>
</AssignMessage>
<!-- <Add>
        <Headers>
            <Header name="SOAPAction">oracle-Facade-SalesOrderServiceContract</Header>
        </Headers>
    </Add> 
-->
```

Local Run

```
$ policytype=$(xmllint -xpath "/*" "$proxypolicy" | awk '/./{line=$0} END{print line}' | sed 's@</\(.*\)>@\1@' )
$ echo $policytype
AssignMessage
$ policytype=$(awk '/./{line=$0} END{print line}' "$proxypolicy" | sed 's@</\(.*\)>@\1@' )
$ echo $policytype
-->
$ 
```


## Housekeeping
(please check all that apply [X], do not edit the text)
- [X] I have run all the tests locally and they all pass.
- [X] I have followed the relevant style guide for my changes.
- [ ] PR requires full pipeline run (Run for changes only by default).

**CC:** @apigee-devrel-reviewers
