### PR TITLE
Fix for proxy report , latestrevision fetch fix for proxy with whitespace in name 

### DIFF
--- a/tools/apigee-sackmesser/cmd/report/report.sh
+++ b/tools/apigee-sackmesser/cmd/report/report.sh
@@ -96,6 +96,8 @@ if [ "$skip_api_lint" == "false" ]; then
         apigeelint -s "$proxyexportpath/apiproxy" -f html.js > "$export_folder/apigeelint/proxies/$proxyname.html" || true # apigeelint exits on error but we want to continue
         apigeelint -s "$proxyexportpath/apiproxy" -f json.js > "$export_folder/apigeelint/proxies/$proxyname.json" || true #
     done <   <(find "$export_folder/$organization/proxies" -type d -mindepth 1 -maxdepth 1 -print0)
+else
+    loginfo "Skipping Apigeelint as SKIP_API_LINT env var is set to true"
 fi
 
 performancequery="organizations/$organization/environments/$environment/stats/apiproxy"

--- a/tools/apigee-sackmesser/cmd/report/report.sh
+++ b/tools/apigee-sackmesser/cmd/report/report.sh
@@ -160,7 +160,8 @@ echo "<tbody class=\"mdc-data-table__content\">" >> "$report_html"
 
 while IFS= read -r -d '' proxylint
 do
-    proxyname=$(basename "${proxylint%%.*}")
+    proxyname=$(basename "$proxylint")
+    proxyname=${proxyname//.json/}
     proxyexportpath="$export_folder/$organization/proxies/$proxyname"
     if jq -e . >/dev/null 2>&1 <<<"$(cat "$proxylint")"; then
         errorCount=$(jq '[.[].errorCount] | add' "$proxylint")

--- a/tools/apigee-sackmesser/cmd/report/report.sh
+++ b/tools/apigee-sackmesser/cmd/report/report.sh
@@ -169,7 +169,7 @@ do
         errorCount=$(jq '[.[].errorCount] | add' "$proxylint")
         warningCount=$(jq '[.[].warningCount] | add' "$proxylint")
     else
-        loginfo "Failed to parse JSON $proxylint, Skipping errorCount & warningCount check !"
+        logwarn "Failed to parse JSON $proxylint, Skipping errorCount & warningCount check !"
         errorCount=0
         warningCount=0
     fi
@@ -350,7 +350,7 @@ do
         errorCount=$(jq '[.[].errorCount] | add' "$sflint")
         warningCount=$(jq '[.[].warningCount] | add' "$sflint")
     else
-        loginfo "Failed to parse JSON $sflint, Skipping errorCount & warningCount check !"
+        logwarn "Failed to parse JSON $sflint, Skipping errorCount & warningCount check !"
         errorCount=0
         warningCount=0
     fi


### PR DESCRIPTION
## Description
tools/apigee-sackmesser/cmd/report/report.sh

- Skipping apigeelint  output json which fails to JSON parse

```
if jq -e . >/dev/null 2>&1 <<<"$(cat "$proxylint")"; then
        errorCount=$(jq '[.[].errorCount] | add' "$proxylint")
        warningCount=$(jq '[.[].warningCount] | add' "$proxylint")
    else
        loginfo "Failed to parse JSON $proxylint, Skipping errorCount & warningCount check !"
        errorCount=0
        warningCount=0
    fi
```

AND 

```
if jq -e . >/dev/null 2>&1 <<<"$(cat "$sflint")"; then
        errorCount=$(jq '[.[].errorCount] | add' "$sflint")
        warningCount=$(jq '[.[].warningCount] | add' "$sflint")
    else
        loginfo "Failed to parse JSON $sflint, Skipping errorCount & warningCount check !"
        errorCount=0
        warningCount=0
    fi
```
- `latestrevision` fetch fix for proxies with whitespace in name

```
latestrevision=$(xmllint --xpath 'string(/APIProxy/@revision)' "/$proxyexportpath/apiproxy/${proxyname//%20/ }.xml")
latestrevision=$(xmllint --xpath 'string(/SharedFlowBundle/@revision)' "/$sfexportpath/sharedflowbundle/${sfname//%20/ }.xml")
```
- exposed environment  var `SKIP_API_EXPORT`
- exposed environment var `SKIP_API_LINT`

Can be used as while fetching report
```
docker run \
  -e "SKIP_API_EXPORT=true" \
  -e "SKIP_API_LINT=true" \
  -v "$PWD":/opt/apigee   \
  anaik91/apigee-sackmesser:v4 report --apigeeapi -t <redacted> -o se-non-prod -e dev
```


**Fixes:** #issue

## Housekeeping
(please check all that apply [X], do not edit the text)
- [X] I have run all the tests locally and they all pass.
- [X] I have followed the relevant style guide for my changes.
- [ ] PR requires full pipeline run (Run for changes only by default).

**CC:** @apigee-devrel-reviewers
