### PR TITLE
Feature/bump hybrid 165 + Workload Identitites

### DIFF
--- a/tools/hybrid-quickstart/initialize-runtime-gke.sh
+++ b/tools/hybrid-quickstart/initialize-runtime-gke.sh
@@ -64,10 +64,9 @@ download_apigee_ctl
 prepare_resources
 
 # create certificate for env group hostname
-
 create_cert $ENV_GROUP_NAME
 
-# create all required service accounts and download their keys
+# # create all required service accounts and prepare workload identities
 create_sa
 
 # configure the Apigee runtime

--- a/tools/hybrid-quickstart/steps.sh
+++ b/tools/hybrid-quickstart/steps.sh
@@ -622,10 +622,10 @@ EOF
 create_k8s_sa_workload() {
   K8S_SA=$1
   GCP_SA=$2
-  kubectl create sa -n apigee $K8S_SA || echo "$K8S_SA exists"
-  kubectl annotate sa --overwrite -n apigee $K8S_SA iam.gke.io/gcp-service-account=$GCP_SA
+  kubectl create sa -n apigee "$K8S_SA" || echo "$K8S_SA exists"
+  kubectl annotate sa --overwrite -n apigee "$K8S_SA" "iam.gke.io/gcp-service-account=$GCP_SA"
 
-  gcloud iam service-accounts add-iam-policy-binding $GCP_SA \
+  gcloud iam service-accounts add-iam-policy-binding "$GCP_SA" \
     --role roles/iam.workloadIdentityUser \
     --member "serviceAccount:$PROJECT_ID.svc.id.goog[apigee/$K8S_SA]"
 }

--- a/tools/hybrid-quickstart/steps.sh
+++ b/tools/hybrid-quickstart/steps.sh
@@ -683,25 +683,6 @@ instanceID: "$PROJECT_ID-$(date +%s)"
 
 envs:
   - name: $ENV_NAME
-    serviceAccountPaths:
-      synchronizer: "$HYBRID_HOME/service-accounts/$PROJECT_ID-apigee-synchronizer.json"
-      udca: "$HYBRID_HOME/service-accounts/$PROJECT_ID-apigee-udca.json"
-      runtime: "$HYBRID_HOME/service-accounts/$PROJECT_ID-apigee-runtime.json"
-# mart:
-#   serviceAccountPath: "$HYBRID_HOME/service-accounts/$PROJECT_ID-apigee-mart.json"
-
-# connectAgent:
-#   serviceAccountPath: "$HYBRID_HOME/service-accounts/$PROJECT_ID-apigee-mart.json"
-
-# udca:
-#   serviceAccountPath: "$HYBRID_HOME/service-accounts/$PROJECT_ID-apigee-udca.json"
-
-# metrics:
-#   enabled: false
-#   serviceAccountPath: "$HYBRID_HOME/service-accounts/$PROJECT_ID-apigee-metrics.json"
-
-# watcher:
-  # serviceAccountPath: "$HYBRID_HOME/service-accounts/$PROJECT_ID-apigee-watcher.json"
 
 logger:
   enabled: false

--- a/tools/hybrid-quickstart/steps.sh
+++ b/tools/hybrid-quickstart/steps.sh
@@ -39,7 +39,7 @@ set_config_params() {
     export GKE_CLUSTER_NAME=${GKE_CLUSTER_NAME:-apigee-hybrid}
     export GKE_CLUSTER_MACHINE_TYPE=${GKE_CLUSTER_MACHINE_TYPE:-e2-standard-4}
     echo "- GKE Node Type $GKE_CLUSTER_MACHINE_TYPE"
-    export APIGEE_CTL_VERSION='1.6.4'
+    export APIGEE_CTL_VERSION='1.6.5'
     echo "- Apigeectl version $APIGEE_CTL_VERSION"
     export KPT_VERSION='v0.34.0'
     echo "- kpt version $KPT_VERSION"


### PR DESCRIPTION
## Description
What's changed, or what was fixed?

- Bump Apigee hybrid to 1.6.5
- Use Workload identities instead of downloading Service accounts

## Housekeeping
(please check all that apply [X], do not edit the text)
- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.
- [ ] PR requires full pipeline run (Run for changes only by default).

**CC:** @apigee-devrel-reviewers
