### PR TITLE
Private cluster for the hybrid quick start

### DIFF
--- a/tools/hybrid-quickstart/README.md
+++ b/tools/hybrid-quickstart/README.md
@@ -72,6 +72,13 @@ export REGION='europe-west1'
 export ZONE='europe-west1-c'
 ```
 
+### Networking
+
+```sh
+export NETWORK='apigee-hybrid'
+export SUBNET='apigee-europe-west1'
+```
+
 ### Runtime GKE cluster
 
 ```sh


### PR DESCRIPTION
## Description
What's changed, or what was fixed?

- Private Cluster for Apigee Hybrid Quickstart
- No longer assumes the existence of a `default` network
- Masks the bearer token before logging it to the console

## Housekeeping
(please check all that apply [X], do not edit the text)
- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.
- [ ] PR requires full pipeline run (Run for changes only by default).

**CC:** @apigee-devrel-reviewers
