### PR TITLE
quickstart: check that internal LB is never used with google-managed cets

### DIFF
--- a/tools/hybrid-quickstart/destroy-runtime-gke.sh
+++ b/tools/hybrid-quickstart/destroy-runtime-gke.sh
@@ -21,6 +21,9 @@ source "$QUICKSTART_ROOT/steps.sh"
 
 set_config_params
 
+# ask for confirmation (skip with QUIET_INSTALL=true)
+ask_confirm
+
 echo "🗑️ Delete Apigee hybrid cluster"
 
 yes | gcloud container clusters delete "$GKE_CLUSTER_NAME" --region "$REGION"

--- a/tools/hybrid-quickstart/steps.sh
+++ b/tools/hybrid-quickstart/steps.sh
@@ -44,7 +44,7 @@ set_config_params() {
     echo "- TLS Certificate $CERT_TYPE"
 
     if [ "$CERT_TYPE" == "google-managed" ] && [ "$INGRESS_TYPE" != "external" ]; then
-        echo "Google Managed Certificates can only be used with an external ingress. SET CERT_TYPE to 'self-signed' (for the scrit to create one for you) or 'skip' if you want to provide your own as a k8s secret later."
+        echo "Google Managed Certificates can only be used with an external ingress. SET CERT_TYPE to 'self-signed' (for the script to create one for you) or 'skip' if you want to provide your own as a k8s secret later."
         exit 1
     fi
 

--- a/tools/hybrid-quickstart/steps.sh
+++ b/tools/hybrid-quickstart/steps.sh
@@ -141,7 +141,7 @@ ask_confirm() {
     REPLY=${REPLY:-Y}
 
     if [[ "$REPLY" =~ ^[Yy]$ ]]; then
-      echo "starting provisioning"
+      echo "continuing"
     else
       exit 1
     fi

--- a/tools/hybrid-quickstart/steps.sh
+++ b/tools/hybrid-quickstart/steps.sh
@@ -43,6 +43,11 @@ set_config_params() {
     export CERT_TYPE=${CERT_TYPE:-google-managed}
     echo "- TLS Certificate $CERT_TYPE"
 
+    if [ "$CERT_TYPE" == "google-managed" ] && [ "$INGRESS_TYPE" != "external" ]; then
+        echo "Google Managed Certificates can only be used with an external ingress. SET CERT_TYPE to 'self-signed' (for the scrit to create one for you) or 'skip' if you want to provide your own as a k8s secret later."
+        exit 1
+    fi
+
     export GKE_CLUSTER_NAME=${GKE_CLUSTER_NAME:-apigee-hybrid}
     export GKE_CLUSTER_MACHINE_TYPE=${GKE_CLUSTER_MACHINE_TYPE:-e2-standard-4}
     echo "- GKE Node Type $GKE_CLUSTER_MACHINE_TYPE"
@@ -318,7 +323,7 @@ configure_network() {
       elif [[ "$INGRESS_TYPE" == "external" && "$CERT_TYPE" == "self-signed" ]]; then
         gcloud compute addresses create apigee-ingress-ip --region "$REGION"
       else
-        gcloud compute addresses create apigee-ingress-ip --region "$REGION" --network "$NETWORK" --subnet "$SUBNET" --purpose SHARED_LOADBALANCER_VIP
+        gcloud compute addresses create apigee-ingress-ip --region "$REGION" --subnet "$SUBNET" --purpose SHARED_LOADBALANCER_VIP
       fi
     fi
     INGRESS_IP=$(gcloud compute addresses list --format json --filter "name=apigee-ingress-ip" --format="get(address)")
@@ -335,7 +340,7 @@ configure_network() {
       if [[ "$INGRESS_TYPE" == "external" ]]; then
         gcloud dns managed-zones create apigee-dns-zone --dns-name="$DNS_NAME" --description=apigee-dns-zone
       else
-        gcloud dns managed-zones create apigee-dns-zone --dns-name="$DNS_NAME" --description=apigee-dns-zone --visibility="private" --networks="default"
+        gcloud dns managed-zones create apigee-dns-zone --dns-name="$DNS_NAME" --description=apigee-dns-zone --visibility="private" --networks="$NETWORK"
       fi
 
       rm -f transaction.yaml
@@ -649,7 +654,8 @@ spec:
         port:
           number: 15021 # for ASM 1.7.x and above, else 15020
 EOF
-
+  else
+    kubectl create ns apigee
   fi
 }
 


### PR DESCRIPTION
## Description
What's changed, or what was fixed?

- Safeguard to ensure internal load balancer isn't used with google-managed certificate issuer
- Use custom network on the ILB

**Fixes:** #483 

## Housekeeping
(please check all that apply [X], do not edit the text)
- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.
- [ ] PR requires full pipeline run (Run for changes only by default).

**CC:** @apigee-devrel-reviewers
