### PR TITLE
Squashed Dependabot: Bump minimist from 1.2.5 to 1.2.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -365,7 +365,6 @@
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.2",
         "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
@@ -1339,9 +1338,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -3537,9 +3536,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "ms": {
       "version": "2.1.2",

--- a/references/cicd-sharedflow-pipeline/package-lock.json
+++ b/references/cicd-sharedflow-pipeline/package-lock.json
@@ -10,7 +10,7 @@
 			"devDependencies": {
 				"@cucumber/cucumber": "^7.3.0",
 				"apickli": "^3.0.1",
-				"apigeelint": "^2.6.0",
+				"apigeelint": "^2.13.0",
 				"eslint": "^7.0.0",
 				"eslint-config-google": "^0.14.0",
 				"eslint-config-prettier": "^6.11.0"
@@ -471,12 +471,12 @@
 			}
 		},
 		"node_modules/ansi-regex": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-			"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
 			"dev": true,
 			"engines": {
-				"node": ">=6"
+				"node": ">=8"
 			}
 		},
 		"node_modules/ansi-styles": {
@@ -517,17 +517,16 @@
 			}
 		},
 		"node_modules/apigeelint": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/apigeelint/-/apigeelint-2.9.0.tgz",
-			"integrity": "sha512-Wvzt9VHvr06Buk7r+ba53JLCr24gB+8Kd4qwU5TbOr44k0Wn/G7a6yYZPPQCfRw1+7TK/H8VEjHnV20R+fGzxA==",
+			"version": "2.21.2",
+			"resolved": "https://registry.npmjs.org/apigeelint/-/apigeelint-2.21.2.tgz",
+			"integrity": "sha512-yteaLuX8qQEBCLHxWn1E4xN0QJcjInmsCe70Gif8Owb9XbYje0jycVEmFKdcXzdQ+J7Sc7DxTgugk3z6b1RDkQ==",
 			"dev": true,
 			"dependencies": {
 				"@xmldom/xmldom": "^0.7.4",
 				"babel-code-frame": "latest",
-				"chalk": "latest",
+				"chalk": "4.1.2",
 				"commander": "^2.9.0",
 				"debug": "latest",
-				"decache": "latest",
 				"decompress": "latest",
 				"eslint": "latest",
 				"js-yaml": "latest",
@@ -539,15 +538,17 @@
 				"path": ">= 0.11.14",
 				"pdfmake": "latest",
 				"pluralize": "latest",
-				"request": "latest",
-				"strip-ansi": "5.2.0",
+				"strip-ansi": "^6.0.1",
 				"table": "latest",
 				"text-table": "latest",
-				"util": "^0.10.3",
 				"xpath": "latest"
 			},
 			"bin": {
 				"apigeelint": "cli.js"
+			},
+			"engines": {
+				"node": ">= 12.22.0",
+				"npm": ">= 8.3.0"
 			}
 		},
 		"node_modules/apigeelint/node_modules/commander": {
@@ -1039,15 +1040,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/callsite": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-			"integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
-			"dev": true,
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1115,7 +1107,6 @@
 			"integrity": "sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==",
 			"dev": true,
 			"dependencies": {
-				"colors": "^1.1.2",
 				"object-assign": "^4.1.0",
 				"string-width": "^4.2.0"
 			},
@@ -1374,15 +1365,6 @@
 				"supports-color": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/decache": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/decache/-/decache-4.6.0.tgz",
-			"integrity": "sha512-PppOuLiz+DFeaUvFXEYZjLxAkKiMYH/do/b/MxpDe/8AgKBi5GhZxridoVIbBq72GDbL36e4p0Ce2jTGUwwU+w==",
-			"dev": true,
-			"dependencies": {
-				"callsite": "^1.0.0"
 			}
 		},
 		"node_modules/decompress": {
@@ -1889,8 +1871,7 @@
 			"dependencies": {
 				"esprima": "~1.0.4",
 				"estraverse": "~1.5.0",
-				"esutils": "~1.0.0",
-				"source-map": "~0.1.30"
+				"esutils": "~1.0.0"
 			},
 			"bin": {
 				"escodegen": "bin/escodegen.js",
@@ -2051,15 +2032,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/eslint/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/eslint/node_modules/argparse": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -2093,18 +2065,6 @@
 			},
 			"bin": {
 				"js-yaml": "bin/js-yaml.js"
-			}
-		},
-		"node_modules/eslint/node_modules/strip-ansi": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-			"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-			"dev": true,
-			"dependencies": {
-				"ansi-regex": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=8"
 			}
 		},
 		"node_modules/espree": {
@@ -3645,9 +3605,9 @@
 			}
 		},
 		"node_modules/minimist": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
 			"dev": true
 		},
 		"node_modules/mkdirp": {
@@ -4736,8 +4696,7 @@
 				"esprima": "^4.0.1",
 				"estraverse": "^4.2.0",
 				"esutils": "^2.0.2",
-				"optionator": "^0.8.1",
-				"source-map": "~0.6.1"
+				"optionator": "^0.8.1"
 			},
 			"bin": {
 				"escodegen": "bin/escodegen.js",
@@ -4855,8 +4814,7 @@
 				"esprima": "^4.0.1",
 				"estraverse": "^4.2.0",
 				"esutils": "^2.0.2",
-				"optionator": "^0.8.1",
-				"source-map": "~0.6.1"
+				"optionator": "^0.8.1"
 			},
 			"bin": {
 				"escodegen": "bin/escodegen.js",
@@ -5026,37 +4984,16 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/string-width/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
-		"node_modules/string-width/node_modules/strip-ansi": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-			"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-			"dev": true,
-			"dependencies": {
-				"ansi-regex": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/strip-ansi": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-			"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 			"dev": true,
 			"dependencies": {
-				"ansi-regex": "^4.1.0"
+				"ansi-regex": "^5.0.1"
 			},
 			"engines": {
-				"node": ">=6"
+				"node": ">=8"
 			}
 		},
 		"node_modules/strip-dirs": {
@@ -5287,15 +5224,6 @@
 				"url": "https://github.com/sponsors/epoberezkin"
 			}
 		},
-		"node_modules/table/node_modules/ansi-regex": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=8"
-			}
-		},
 		"node_modules/table/node_modules/json-schema-traverse": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -5307,18 +5235,6 @@
 			"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
 			"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
 			"dev": true
-		},
-		"node_modules/table/node_modules/strip-ansi": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-			"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-			"dev": true,
-			"dependencies": {
-				"ansi-regex": "^5.0.0"
-			},
-			"engines": {
-				"node": ">=8"
-			}
 		},
 		"node_modules/tar-stream": {
 			"version": "1.6.2",
@@ -5794,7 +5710,6 @@
 			"integrity": "sha512-7tDlwhrBG+oYFdXNOjILSurpfQyuVgkRe3hB2q8TEssamDHB7BbLWYkYO98nTn0FibfdFroFKDjndbgufAgS/Q==",
 			"dev": true,
 			"dependencies": {
-				"commander": "^2.7.1",
 				"core-js": "^2.5.7",
 				"lodash.get": "^4.0.0",
 				"lodash.isequal": "^4.0.0",
@@ -6202,9 +6117,9 @@
 			"dev": true
 		},
 		"ansi-regex": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-			"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
 			"dev": true
 		},
 		"ansi-styles": {
@@ -6239,17 +6154,16 @@
 			}
 		},
 		"apigeelint": {
-			"version": "2.9.0",
-			"resolved": "https://registry.npmjs.org/apigeelint/-/apigeelint-2.9.0.tgz",
-			"integrity": "sha512-Wvzt9VHvr06Buk7r+ba53JLCr24gB+8Kd4qwU5TbOr44k0Wn/G7a6yYZPPQCfRw1+7TK/H8VEjHnV20R+fGzxA==",
+			"version": "2.21.2",
+			"resolved": "https://registry.npmjs.org/apigeelint/-/apigeelint-2.21.2.tgz",
+			"integrity": "sha512-yteaLuX8qQEBCLHxWn1E4xN0QJcjInmsCe70Gif8Owb9XbYje0jycVEmFKdcXzdQ+J7Sc7DxTgugk3z6b1RDkQ==",
 			"dev": true,
 			"requires": {
 				"@xmldom/xmldom": "^0.7.4",
 				"babel-code-frame": "latest",
-				"chalk": "latest",
+				"chalk": "4.1.2",
 				"commander": "^2.9.0",
 				"debug": "latest",
-				"decache": "latest",
 				"decompress": "latest",
 				"eslint": "latest",
 				"js-yaml": "latest",
@@ -6261,11 +6175,9 @@
 				"path": ">= 0.11.14",
 				"pdfmake": "latest",
 				"pluralize": "latest",
-				"request": "latest",
-				"strip-ansi": "5.2.0",
+				"strip-ansi": "^6.0.1",
 				"table": "latest",
 				"text-table": "latest",
-				"util": "^0.10.3",
 				"xpath": "latest"
 			},
 			"dependencies": {
@@ -6697,12 +6609,6 @@
 				"get-intrinsic": "^1.0.2"
 			}
 		},
-		"callsite": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
-			"integrity": "sha1-KAOY5dZkvXQDi28JBRU+borxvCA=",
-			"dev": true
-		},
 		"callsites": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -6978,15 +6884,6 @@
 			"dev": true,
 			"requires": {
 				"ms": "2.1.2"
-			}
-		},
-		"decache": {
-			"version": "4.6.0",
-			"resolved": "https://registry.npmjs.org/decache/-/decache-4.6.0.tgz",
-			"integrity": "sha512-PppOuLiz+DFeaUvFXEYZjLxAkKiMYH/do/b/MxpDe/8AgKBi5GhZxridoVIbBq72GDbL36e4p0Ce2jTGUwwU+w==",
-			"dev": true,
-			"requires": {
-				"callsite": "^1.0.0"
 			}
 		},
 		"decompress": {
@@ -7498,12 +7395,6 @@
 				"v8-compile-cache": "^2.0.3"
 			},
 			"dependencies": {
-				"ansi-regex": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-					"dev": true
-				},
 				"argparse": {
 					"version": "1.0.10",
 					"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -7527,15 +7418,6 @@
 					"requires": {
 						"argparse": "^1.0.7",
 						"esprima": "^4.0.0"
-					}
-				},
-				"strip-ansi": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^5.0.0"
 					}
 				}
 			}
@@ -8868,9 +8750,9 @@
 			}
 		},
 		"minimist": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
 			"dev": true
 		},
 		"mkdirp": {
@@ -9977,32 +9859,15 @@
 				"emoji-regex": "^8.0.0",
 				"is-fullwidth-code-point": "^3.0.0",
 				"strip-ansi": "^6.0.0"
-			},
-			"dependencies": {
-				"ansi-regex": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-					"dev": true
-				},
-				"strip-ansi": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^5.0.0"
-					}
-				}
 			}
 		},
 		"strip-ansi": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-			"integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 			"dev": true,
 			"requires": {
-				"ansi-regex": "^4.1.0"
+				"ansi-regex": "^5.0.1"
 			}
 		},
 		"strip-dirs": {
@@ -10205,12 +10070,6 @@
 						"uri-js": "^4.2.2"
 					}
 				},
-				"ansi-regex": {
-					"version": "5.0.1",
-					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-					"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-					"dev": true
-				},
 				"json-schema-traverse": {
 					"version": "1.0.0",
 					"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -10222,15 +10081,6 @@
 					"resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
 					"integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
 					"dev": true
-				},
-				"strip-ansi": {
-					"version": "6.0.0",
-					"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
-					"integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
-					"dev": true,
-					"requires": {
-						"ansi-regex": "^5.0.0"
-					}
 				}
 			}
 		},

--- a/references/dutch-healthcare/healthcare-v1/package-lock.json
+++ b/references/dutch-healthcare/healthcare-v1/package-lock.json
@@ -1619,9 +1619,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/mkdirp": {
       "version": "0.5.5",
@@ -4318,9 +4318,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "mkdirp": {
       "version": "0.5.5",

--- a/references/identity-facade/package-lock.json
+++ b/references/identity-facade/package-lock.json
@@ -1810,9 +1810,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/mkdirp": {
@@ -4655,9 +4655,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "mkdirp": {

--- a/references/kvm-admin-api/package-lock.json
+++ b/references/kvm-admin-api/package-lock.json
@@ -373,7 +373,6 @@
       "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.0.tgz",
       "integrity": "sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==",
       "dependencies": {
-        "colors": "^1.1.2",
         "object-assign": "^4.1.0",
         "string-width": "^4.2.0"
       },
@@ -1399,9 +1398,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "node_modules/mkdirp": {
       "version": "0.5.5",
@@ -2352,7 +2351,6 @@
       "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-3.25.1.tgz",
       "integrity": "sha512-7tDlwhrBG+oYFdXNOjILSurpfQyuVgkRe3hB2q8TEssamDHB7BbLWYkYO98nTn0FibfdFroFKDjndbgufAgS/Q==",
       "dependencies": {
-        "commander": "^2.7.1",
         "core-js": "^2.5.7",
         "lodash.get": "^4.0.0",
         "lodash.isequal": "^4.0.0",
@@ -3570,9 +3568,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
     },
     "mkdirp": {
       "version": "0.5.5",

--- a/references/southbound-mtls/package-lock.json
+++ b/references/southbound-mtls/package-lock.json
@@ -411,7 +411,6 @@
       "integrity": "sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==",
       "dev": true,
       "dependencies": {
-        "colors": "^1.1.2",
         "object-assign": "^4.1.0",
         "string-width": "^4.2.0"
       },
@@ -1560,9 +1559,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/mkdirp": {
@@ -2621,7 +2620,6 @@
       "integrity": "sha512-7tDlwhrBG+oYFdXNOjILSurpfQyuVgkRe3hB2q8TEssamDHB7BbLWYkYO98nTn0FibfdFroFKDjndbgufAgS/Q==",
       "dev": true,
       "dependencies": {
-        "commander": "^2.7.1",
         "core-js": "^2.5.7",
         "lodash.get": "^4.0.0",
         "lodash.isequal": "^4.0.0",
@@ -4002,9 +4000,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "mkdirp": {

--- a/references/threat-protect/package-lock.json
+++ b/references/threat-protect/package-lock.json
@@ -1810,9 +1810,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "node_modules/mkdirp": {
@@ -4655,9 +4655,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "mkdirp": {

--- a/tools/apigee-sackmesser/test/integration/filter.feature
+++ b/tools/apigee-sackmesser/test/integration/filter.feature
@@ -15,4 +15,4 @@ Feature: Sackmesser Example
 
   Scenario: Invalid path
     When I GET /not-part-of-oas
-    Then response code should be 500
+    Then response code should be 400

--- a/tools/apigee-sackmesser/test/package-lock.json
+++ b/tools/apigee-sackmesser/test/package-lock.json
@@ -1561,9 +1561,9 @@
             }
         },
         "node_modules/minimist": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
             "dev": true
         },
         "node_modules/mkdirp": {
@@ -4007,9 +4007,9 @@
             }
         },
         "minimist": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+            "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
             "dev": true
         },
         "mkdirp": {

--- a/tools/apigee-sackmesser/test/sackmesser-example/apiproxy/policies/AM-FailedOASValidation.xml
+++ b/tools/apigee-sackmesser/test/sackmesser-example/apiproxy/policies/AM-FailedOASValidation.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<!--
+ Copyright 2022 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+<AssignMessage name="AM-FailedOASValidation">
+    <Set>
+        <StatusCode>400</StatusCode>
+        <ReasonPhrase>Bad Request</ReasonPhrase>
+        <Payload contentType="application/json">{"code": "400.01.01", "message": "Bad Request, check OAS."}</Payload>
+    </Set>
+</AssignMessage>

--- a/tools/apigee-sackmesser/test/sackmesser-example/apiproxy/proxies/default.xml
+++ b/tools/apigee-sackmesser/test/sackmesser-example/apiproxy/proxies/default.xml
@@ -15,18 +15,26 @@
  limitations under the License.
 -->
 <ProxyEndpoint name="default">
+    <FaultRules>
+        <FaultRule name="oas-failed">
+            <Condition>OASValidation.OA-Validation.failed = true</Condition>
+            <Step>
+                <Name>AM-FailedOASValidation</Name>
+            </Step>
+        </FaultRule>
+    </FaultRules>
     <PreFlow name="PreFlow">
         <Request>
             <Step>
                 <Name>OA-Validation</Name>
             </Step>
         </Request>
-        <Response/>
+        <Response />
     </PreFlow>
-    <Flows/>
+    <Flows />
     <PostFlow name="PostFlow">
-        <Request/>
-        <Response/>
+        <Request />
+        <Response />
     </PostFlow>
     <HTTPProxyConnection>
         <BasePath>/sackmesser-example-v1</BasePath>


### PR DESCRIPTION
## Description
What's changed, or what was fixed?

- Bump minimist from 1.2.5 to 1.2.6
- OAS Policy error code changed for missing path (500 -> 400)

**Fixes:** #489 #492 #493 #494 #495 #496 #497 #499

## Housekeeping
(please check all that apply [X], do not edit the text)
- [ ] I have run all the tests locally and they all pass.
- [ ] I have followed the relevant style guide for my changes.
- [ ] PR requires full pipeline run (Run for changes only by default).

**CC:** @apigee-devrel-reviewers
