### PR TITLE
bump hybrid quickstart to 1.7

### DIFF
--- a/tools/hybrid-quickstart/cloudbuild.yaml
+++ b/tools/hybrid-quickstart/cloudbuild.yaml
@@ -20,6 +20,7 @@ steps:
     args:
       - "-c"
       - |-
+        gcloud components update # b/229248353
         apt-get update && apt-get install zip -y
         ./initialize-runtime-gke.sh || touch .failure
     env:
@@ -78,4 +79,4 @@ substitutions:
   _QUICKSTART_ENV_NAME: test1
   _QUICKSTART_ENV_GROUP_NAME: test
   _DESTROY_AFTER_VALIDATION: "false"
-  _CERT_TYPE: "" # default (let's encrypt)
+  _CERT_TYPE: "" # default: 'google-managed'


### PR DESCRIPTION
## Description
What's changed, or what was fixed?

Bump quickstart to:
- hybrid 1.7
- ASM 1.12
- cert manager 1.7.4

**Fixes:** #issue

## Housekeeping
(please check all that apply [X], do not edit the text)
- [x] I have run all the tests locally and they all pass.
- [ x] I have followed the relevant style guide for my changes.
- [ ] PR requires full pipeline run (Run for changes only by default).

**CC:** @apigee-devrel-reviewers
