### PR TITLE
clean up asm registration when deleting the cluster

### DIFF
--- a/tools/hybrid-quickstart/cloudbuild.yaml
+++ b/tools/hybrid-quickstart/cloudbuild.yaml
@@ -20,7 +20,7 @@ steps:
     args:
       - "-c"
       - |-
-        gcloud components update # b/229248353
+        gcloud version
         apt-get update && apt-get install zip -y
         ./initialize-runtime-gke.sh || touch .failure
     env:

--- a/tools/hybrid-quickstart/destroy-runtime-gke.sh
+++ b/tools/hybrid-quickstart/destroy-runtime-gke.sh
@@ -32,8 +32,11 @@ for persistent_disk in $(gcloud compute disks list --format="value(name)" --filt
    gcloud compute disks delete "$persistent_disk" --zone="$ZONE" -q
 done
 
-echo "✅ Apigee hybrid cluster deleted"
+for cluster in $(gcloud container hub memberships list --format="value(name)"); do
+   gcloud container hub memberships delete "$cluster" -q
+done
 
+echo "✅ Apigee hybrid cluster deleted"
 
 echo "🗑️ Clean up Networking"
 


### PR DESCRIPTION
## Description
What's changed, or what was fixed?

- Cleanly clean up hub registrations that ASM 1.12 registers
- Skip the component update as the default 381 is stable again 

**Fixes:** #530 

## Housekeeping
(please check all that apply [X], do not edit the text)
- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.
- [ ] PR requires full pipeline run (Run for changes only by default).

**CC:** @apigee-devrel-reviewers
