### PR TITLE
Mask sa access token using Mask Passwords plugin 

### DIFF
--- a/references/cicd-pipeline/ci-config/jenkins/Jenkinsfile
+++ b/references/cicd-pipeline/ci-config/jenkins/Jenkinsfile
@@ -193,7 +193,7 @@ pipeline {
                  env.SA_TOKEN=sh(script:'gcloud auth application-default print-access-token', returnStdout: true).trim()
               }
 
-wrap([$class: 'MaskPasswordsBuildWrapper', varPasswordPairs: [[password: token, var: 'SA_TOKEN']]]) {
+wrap([$class: 'MaskPasswordsBuildWrapper', varPasswordPairs: [[password: "env.SA_TOKEN", var: 'SA_TOKEN']]]) {
              sh """
                 mvn clean install \
                   -Pgoogleapi \

--- a/references/cicd-pipeline/ci-config/jenkins/Jenkinsfile
+++ b/references/cicd-pipeline/ci-config/jenkins/Jenkinsfile
@@ -203,8 +203,8 @@ pipeline {
                    -Ddeployment.suffix="${env.APIGEE_DEPLOYMENT_SUFFIX}" \
                    -Ddeployment.description="Jenkins Build: ${env.BUILD_TAG} Author: ${env.AUTHOR_EMAIL}"
                 """
+              }
             }
-}
           } }
         }
 

--- a/references/cicd-pipeline/ci-config/jenkins/Jenkinsfile
+++ b/references/cicd-pipeline/ci-config/jenkins/Jenkinsfile
@@ -193,8 +193,8 @@ pipeline {
                  env.SA_TOKEN=sh(script:'gcloud auth application-default print-access-token', returnStdout: true).trim()
               }
 
-              sh """
 wrap([$class: 'MaskPasswordsBuildWrapper', varPasswordPairs: [[password: token, var: 'SA_TOKEN']]]) {
+             sh """
                 mvn clean install \
                   -Pgoogleapi \
                   -Denv="${env.APIGEE_ENV}" \

--- a/references/cicd-pipeline/ci-config/jenkins/Jenkinsfile
+++ b/references/cicd-pipeline/ci-config/jenkins/Jenkinsfile
@@ -193,16 +193,16 @@ pipeline {
                  env.SA_TOKEN=sh(script:'gcloud auth application-default print-access-token', returnStdout: true).trim()
               }
 
-wrap([$class: 'MaskPasswordsBuildWrapper', varPasswordPairs: [[password: env.SA_TOKEN, var: 'SA_TOKEN']]]) {
-             sh """
-                mvn clean install \
-                  -Pgoogleapi \
-                  -Denv="${env.APIGEE_ENV}" \
-                  -Dtoken="${env.SA_TOKEN}" \
-                  -Dorg="${env.APIGEE_ORG}" \
-                  -Ddeployment.suffix="${env.APIGEE_DEPLOYMENT_SUFFIX}" \
-                  -Ddeployment.description="Jenkins Build: ${env.BUILD_TAG} Author: ${env.AUTHOR_EMAIL}"
-              """
+             wrap([$class: 'MaskPasswordsBuildWrapper', varPasswordPairs: [[password: env.SA_TOKEN, var: 'SA_TOKEN']]]) {
+               sh """
+                 mvn clean install \
+                   -Pgoogleapi \
+                   -Denv="${env.APIGEE_ENV}" \
+                   -Dtoken="${env.SA_TOKEN}" \
+                   -Dorg="${env.APIGEE_ORG}" \
+                   -Ddeployment.suffix="${env.APIGEE_DEPLOYMENT_SUFFIX}" \
+                   -Ddeployment.description="Jenkins Build: ${env.BUILD_TAG} Author: ${env.AUTHOR_EMAIL}"
+                """
             }
 }
           } }

--- a/references/cicd-pipeline/ci-config/jenkins/Jenkinsfile
+++ b/references/cicd-pipeline/ci-config/jenkins/Jenkinsfile
@@ -193,7 +193,7 @@ pipeline {
                  env.SA_TOKEN=sh(script:'gcloud auth application-default print-access-token', returnStdout: true).trim()
               }
 
-wrap([$class: 'MaskPasswordsBuildWrapper', varPasswordPairs: [[password: "env.SA_TOKEN", var: 'SA_TOKEN']]]) {
+wrap([$class: 'MaskPasswordsBuildWrapper', varPasswordPairs: [[password: env.SA_TOKEN, var: 'SA_TOKEN']]]) {
              sh """
                 mvn clean install \
                   -Pgoogleapi \

--- a/references/cicd-pipeline/ci-config/jenkins/Jenkinsfile
+++ b/references/cicd-pipeline/ci-config/jenkins/Jenkinsfile
@@ -194,6 +194,7 @@ pipeline {
               }
 
               sh """
+wrap([$class: 'MaskPasswordsBuildWrapper', varPasswordPairs: [[password: token, var: 'SA_TOKEN']]]) {
                 mvn clean install \
                   -Pgoogleapi \
                   -Denv="${env.APIGEE_ENV}" \
@@ -203,6 +204,7 @@ pipeline {
                   -Ddeployment.description="Jenkins Build: ${env.BUILD_TAG} Author: ${env.AUTHOR_EMAIL}"
               """
             }
+}
           } }
         }
 

--- a/references/cicd-pipeline/jenkins-build/plugins.txt
+++ b/references/cicd-pipeline/jenkins-build/plugins.txt
@@ -3,6 +3,7 @@ cucumber-reports:5.7.0
 git:4.11.1
 htmlpublisher:1.30
 junit:1.63
+mask-passwords:3.1
 matrix-project:771.v574584b_39e60
 script-security:1158.v7c1b_73a_69a_08
 token-macro:293.v283932a_0a_b_49


### PR DESCRIPTION
## Description
What's changed, or what was fixed?

- The generated token is visible in Console Output.  Jenkins' Mask Passwords plugin replaces it now with asterisks.
**Fixes:** #issue

## Housekeeping
(please check all that apply [X], do not edit the text)
- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.
- [ ] PR requires full pipeline run (Run for changes only by default).

**CC:** @apigee-devrel-reviewers
