### PR TITLE
increase unit test timeout for Jenkins cicd pipeline

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,7 +7,7 @@ What's changed, or what was fixed?
 **Fixes:** #issue
 
 ## Housekeeping
-(please check all that apply [X], do not edit the text)
+(please check all that apply [x], do not edit the text)
 - [ ] I have run all the tests locally and they all pass.
 - [ ] I have followed the relevant style guide for my changes.
 - [ ] PR requires full pipeline run (Run for changes only by default).

--- a/references/cicd-pipeline/jenkins-build/jenkinsfile-runner/Dockerfile
+++ b/references/cicd-pipeline/jenkins-build/jenkinsfile-runner/Dockerfile
@@ -21,7 +21,7 @@ FROM ${baseImage}:${baseImageTag}
 
 USER root
 WORKDIR /usr/share/jenkins
-RUN jar -xvf jenkins.war
+RUN jar -xf jenkins.war
 USER jenkins
 
 COPY --from=filerunner --chown=jenkins /app /app

--- a/references/cicd-pipeline/package.json
+++ b/references/cicd-pipeline/package.json
@@ -5,7 +5,7 @@
   "author": "danistrebel",
   "scripts": {
     "test": "npm run unit-test && npm run integration-test",
-    "unit-test": "nyc --reporter=html mocha --recursive \"./test/unit/*.js\"",
+    "unit-test": "nyc --reporter=html mocha --recursive \"./test/unit/*.js\" --timeout 5000",
     "integration-test": "cucumber-js ./test/integration",
     "lint": "npm run eslint && npm run apigeelint",
     "eslint": "eslint --format html .",

--- a/tools/pipeline-runner/cloudbuild.yaml
+++ b/tools/pipeline-runner/cloudbuild.yaml
@@ -65,7 +65,7 @@ steps:
       - |-
         max_duration=6960 # cloud build timeout minus 4m
         if [ -n "$_PR_NUMBER" ]; then
-          FULL_PIPELINE_REQUIRED=$(curl "https://api.github.com/repos/$_REPO_GH_ISSUE/issues/$_PR_NUMBER" | jq '.body | contains("[X] PR requires full pipeline run")' )
+          FULL_PIPELINE_REQUIRED=$(curl "https://api.github.com/repos/$_REPO_GH_ISSUE/issues/$_PR_NUMBER" | jq '.body |= ascii_downcase | .body | contains("[x] pr requires full pipeline run")' )
           PROJECTS=$(list-repo-changes.sh)
           if [ "$$FULL_PIPELINE_REQUIRED" = "true" ]; then
             echo "Running Full Pipeline as required in the PR"


### PR DESCRIPTION
## Description
What's changed, or what was fixed?

- increase unit test pipeline timeout for Jenkins cicd reference to 5s (fails only in nightly when some of the CPU is consumed by the hybrid quickstart and trial that are running in parallel)
- case insensitive flag for run all pipelines
- less verbose docker image buid (not listing the entire war content of jenkins)

**Fixes:** #issue

## Housekeeping
(please check all that apply [x], do not edit the text)
- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.
- [ ] PR requires full pipeline run (Run for changes only by default).

**CC:** @apigee-devrel-reviewers
