### PR TITLE
more stable readiness checks for hybrid quickstart

### DIFF
--- a/tools/hybrid-quickstart/cloudbuild.yaml
+++ b/tools/hybrid-quickstart/cloudbuild.yaml
@@ -75,7 +75,7 @@ steps:
           echo "Earlier failure in the pipeline"
           exit -1
         fi
-timeout: 2700s #45min
+timeout: 3600s #60min
 substitutions:
   _QUICKSTART_ENV_NAME: test1
   _QUICKSTART_ENV_GROUP_NAME: test

--- a/tools/hybrid-quickstart/steps.sh
+++ b/tools/hybrid-quickstart/steps.sh
@@ -780,19 +780,19 @@ install_runtime() {
     pushd "$HYBRID_HOME" || return # because apigeectl uses pwd-relative paths
     mkdir -p "$HYBRID_HOME"/generated
 
+    export -f apigeectl_init
     timeout 10m bash -c 'until apigeectl_init; do sleep 20; done'
 
     echo -n "⏳ Waiting for Apigeectl init "
-    "$APIGEECTL_HOME"/apigeectl check-ready -f "$HYBRID_HOME"/overrides/overrides.yaml
     timeout 5m bash -c 'until kubectl wait --for=condition=ready --timeout 10s pod -l app=apigee-controller -n apigee-system; do sleep 10; done'
     timeout 5m bash -c 'until kubectl wait --for=condition=complete --timeout 10s job/apigee-resources-install  -n apigee-system; do sleep 10; done'
 
     echo "Waiting for 30s for the webhook certs to propagate" && sleep 30
 
+    export -f apigeectl_apply
     timeout 10m bash -c 'until apigeectl_apply; do sleep 20; done'
 
     echo -n "⏳ Waiting for Apigeectl apply "
-    "$APIGEECTL_HOME"/apigeectl check-ready -f "$HYBRID_HOME"/overrides/overrides.yaml
     timeout 30m bash -c 'until kubectl wait --for=condition=ready --timeout 10s pod -l app=apigee-runtime -n apigee; do sleep 10; done'
 
     popd || return

--- a/tools/hybrid-quickstart/steps.sh
+++ b/tools/hybrid-quickstart/steps.sh
@@ -783,14 +783,15 @@ install_runtime() {
     mkdir -p "$HYBRID_HOME"/generated
 
     export -f apigeectl_init
-    timeout 12m bash -c 'until apigeectl_init; do sleep 20; done'
+    timeout 20m bash -c 'until apigeectl_init; do sleep 30; done'
 
     echo -n "⏳ Waiting for Apigeectl init "
-    timeout 5m bash -c 'until kubectl wait --for=condition=ready --timeout 60s pod -l app=apigee-controller -n apigee-system; do sleep 10; done'
-    timeout 5m bash -c 'until kubectl wait --for=condition=complete --timeout 60s job/apigee-resources-install  -n apigee-system; do sleep 10; done'
+    timeout 10m bash -c 'until kubectl wait --for=condition=ready --timeout 60s pod -l app=apigee-controller -n apigee-system; do sleep 10; done'
+    timeout 10m bash -c 'until kubectl wait --for=condition=ready --timeout 60s issuer apigee-selfsigned-issuer -n apigee-system; do sleep 10; done'
+    timeout 10m bash -c 'until kubectl wait --for=condition=ready --timeout 60s certificate apigee-serving-cert -n apigee-system; do sleep 10; done'
+    timeout 10m bash -c 'until kubectl wait --for=condition=complete --timeout 60s job/apigee-resources-install  -n apigee-system; do sleep 10; done'
 
     echo -n "⏳ Waiting for Serving Cert "
-    timeout 5m bash -c 'until kubectl wait --for=condition=ready --timeout 60s certificate apigee-serving-cert -n apigee-system; do sleep 10; done'
 
     export -f apigeectl_apply
     timeout 12m bash -c 'until apigeectl_apply; do sleep 20; done'


### PR DESCRIPTION
## Description
What's changed, or what was fixed?

- More complete kubernetes readiness checks
- wait for webhook controller before re-applying after failure

## Housekeeping
(please check all that apply [x], do not edit the text)
- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.
- [ ] PR requires full pipeline run (Run for changes only by default).

**CC:** @apigee-devrel-reviewers
