### PR TITLE
Extend Java reference to support Apigee X

### DIFF
--- a/references/java-callout/pipeline.sh
+++ b/references/java-callout/pipeline.sh
@@ -14,7 +14,15 @@
 # limitations under the License.
 
 set -e
-set -x
 
-mvn install -Ptest -B -ntp
-npm test --prefix proxy-v1
+echo "Testing on Apigee Edge"
+mvn install -Papigee-edge -Dapigee.env="$APIGEE_ENV" -Dapigee.org="$APIGEE_ORG" \
+  -Dapigee.username="$APIGEE_USER" -Dapigee.password="$APIGEE_PASS" -B -ntp
+
+TEST_HOST="$APIGEE_ORG-$APIGEE_ENV.apigee.net" npm test --prefix proxy-v1
+
+echo "Testing on Apigee X"
+mvn install -Papigee-x -Dapigee.env="$APIGEE_X_ENV" -Dapigee.org="$APIGEE_X_ORG" \
+  -Dapigee.bearer="$(gcloud auth print-access-token)" -B -ntp
+
+ TEST_HOST="$APIGEE_X_HOSTNAME" npm test --prefix proxy-v1

--- a/references/java-callout/pom.xml
+++ b/references/java-callout/pom.xml
@@ -23,7 +23,7 @@ xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/
   <artifactId>java-project-v1</artifactId>
   <packaging>pom</packaging>
   <version>1.0</version>
-  <name>Currency Parent Project</name>
+  <name>Java Callout Reference</name>
   <modules>
     <module>java-callout</module>
     <module>proxy-v1</module>

--- a/references/java-callout/proxy-v1/apiproxy/java-v1.xml
+++ b/references/java-callout/proxy-v1/apiproxy/java-v1.xml
@@ -15,7 +15,7 @@
  limitations under the License.
 -->
 
-<APIProxy revision="1" name="currency-v1">
+<APIProxy revision="1" name="java-v1">
     <ConfigurationVersion minorVersion="0" majorVersion="4"/>
 	<Description>@description</Description>
 </APIProxy>

--- a/references/java-callout/proxy-v1/package-lock.json
+++ b/references/java-callout/proxy-v1/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "currency-v1",
+  "name": "java-v1",
   "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "currency-v1",
+      "name": "java-v1",
       "version": "1.0.0",
       "devDependencies": {
         "@cucumber/cucumber": "^7.3.0",

--- a/references/java-callout/proxy-v1/package.json
+++ b/references/java-callout/proxy-v1/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "currency-v1",
+  "name": "java-v1",
   "version": "1.0.0",
   "devDependencies": {
     "@cucumber/cucumber": "^7.3.0",
     "apickli": "^3.0.1"
   },
   "scripts": {
-    "test": "npx cucumber-js test"
+    "test": "npx cucumber-js --publish-quiet test"
   }
 }

--- a/references/java-callout/proxy-v1/pom.xml
+++ b/references/java-callout/proxy-v1/pom.xml
@@ -48,53 +48,43 @@ xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/
     </pluginRepository>
   </pluginRepositories>
   <properties>
-    <project.build.sourceEncoding>
-    UTF-8</project.build.sourceEncoding>
-    <project.reporting.outputEncoding>
-    UTF-8</project.reporting.outputEncoding>
-    <org.slf4j.simpleLogger.defaultLogLevel>
-    info</org.slf4j.simpleLogger.defaultLogLevel>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <org.slf4j.simpleLogger.defaultLogLevel>info</org.slf4j.simpleLogger.defaultLogLevel>
     <project.root.dir>${basedir}</project.root.dir>
     <target.root.dir>${basedir}/target</target.root.dir>
-    <deployment.suffix>${user.name}</deployment.suffix>
-    <commit />
-    <branch>a local</branch>
+    <edge.apigee.plugin.version>1.3.2</edge.apigee.plugin.version>
+    <x.apigee.plugin.version>2.3.1</x.apigee.plugin.version>
   </properties>
   <!-- This is where you add the environment specific properties under various profile names -->
   <!-- For apigee.options, refer to "Advanced Configuration Options" under https://github.com/apigee/apigee-deploy-maven-plugin#pom-xml-sample -->
   <profiles>
     <profile>
-      <id>test</id>
+      <id>apigee-edge</id>
       <properties>
-        <apigee.profile>test</apigee.profile>
+        <apigee.profile>apigee-edge</apigee.profile>
         <apigee.env>test</apigee.env>
         <apigee.hosturl>https://api.enterprise.apigee.com</apigee.hosturl>
         <apigee.apiversion>v1</apigee.apiversion>
         <apigee.org>${env.APIGEE_ORG}</apigee.org>
         <apigee.username>${env.APIGEE_USER}</apigee.username>
         <apigee.password>${env.APIGEE_PASS}</apigee.password>
-        <apigee.options>update</apigee.options>
-        <api.northbound.domain>
-        ${env.API_DOMAIN_TEST}</api.northbound.domain>
-        <api.testtag>~@wip</api.testtag>
+        <apigee.options>override</apigee.options>
+        <apigee.plugin.version>${edge.apigee.plugin.version}</apigee.plugin.version>
       </properties>
     </profile>
     <profile>
-      <id>prod</id>
+      <id>apigee-x</id>
       <properties>
-        <apigee.profile>prod</apigee.profile>
-        <apigee.env>prod</apigee.env>
-        <apigee.hosturl>
-        https://api.enterprise.apigee.com</apigee.hosturl>
+        <apigee.profile>apigee-x</apigee.profile>
+        <apigee.env>test</apigee.env>
+        <apigee.hosturl>https://apigee.googleapis.com</apigee.hosturl>
         <apigee.apiversion>v1</apigee.apiversion>
-        <apigee.org>${env.APIGEE_ORG}</apigee.org>
-        <apigee.username>${env.APIGEE_USER}</apigee.username>
-        <apigee.password>${env.APIGEE_PASS}</apigee.password>
+        <apigee.org>${env.APIGEE_X_ORG}</apigee.org>
+        <apigee.bearer>${bearer}</apigee.bearer>
         <apigee.options>override</apigee.options>
-        <apigee.override.delay>5</apigee.override.delay>
-        <api.northbound.domain>
-        ${env.API_DOMAIN_PROD}</api.northbound.domain>
         <api.testtag>~@wip,~@mock</api.testtag>
+        <apigee.plugin.version>${x.apigee.plugin.version}</apigee.plugin.version>
       </properties>
     </profile>
   </profiles>
@@ -104,7 +94,7 @@ xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/
         <plugin>
           <groupId>io.apigee.build-tools.enterprise4g</groupId>
           <artifactId>apigee-edge-maven-plugin</artifactId>
-          <version>1.3.2</version>
+          <version>${apigee.plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/references/java-callout/proxy-v1/test/features/step_definitions/init.js
+++ b/references/java-callout/proxy-v1/test/features/step_definitions/init.js
@@ -20,10 +20,7 @@ const { Before: before, setDefaultTimeout } = require("@cucumber/cucumber");
 before(function () {
   this.apickli = new apickli.Apickli(
     "https",
-    process.env.APIGEE_ORG +
-      "-" +
-      process.env.APIGEE_ENV +
-      ".apigee.net/apigee-java/v1"
+    process.env.TEST_HOST + "/apigee-java/v1"
   );
 });
 


### PR DESCRIPTION
## Description
What's changed, or what was fixed?

- Add deployment to Apigee X for the java callout reference
- Remove legacy "currency" naming from the proxy

## Housekeeping
(please check all that apply [x], do not edit the text)
- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.
- [ ] PR requires full pipeline run (Run for changes only by default).

**CC:** @apigee-devrel-reviewers
