### PR TITLE
fix jenkins dependency pinning issue

### DIFF
--- a/references/cicd-pipeline/jenkins-build/plugins.txt
+++ b/references/cicd-pipeline/jenkins-build/plugins.txt
@@ -5,7 +5,6 @@ htmlpublisher:1.30
 junit:1.63
 mask-passwords:3.1
 matrix-project:771.v574584b_39e60
-script-security:1172.v35f6a_0b_8207e
 token-macro:293.v283932a_0a_b_49
 workflow-aggregator:2.7
 workflow-step-api:625.vd896b_f445a_f8


### PR DESCRIPTION
## Description
What's changed, or what was fixed?

- remove hardcoded plugin versions for script-security by determining it from the downstream modules.

**Fixes:** #issue

## Housekeeping
(please check all that apply [x], do not edit the text)
- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.
- [ ] PR requires full pipeline run (Run for changes only by default).

**CC:** @apigee-devrel-reviewers
