### PR TITLE
ci: Relax commit message requirement for lower-case format to warning

### DIFF
--- a/.github/config/commitlint.config.js
+++ b/.github/config/commitlint.config.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+module.exports = {
+    extends: ['@commitlint/config-conventional'],
+    rules: {
+        'subject-case': [1, 'always', ['lower-case']]
+    }
+}

--- a/.github/workflows/devrel-static-checks.yml
+++ b/.github/workflows/devrel-static-checks.yml
@@ -22,7 +22,6 @@ on:
   schedule:
     - cron: "0 0 * * *"
 jobs:
-
   license:
     name: License Headers
     runs-on: ubuntu-latest
@@ -58,7 +57,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v2
         with:
-          node-version: '14'
+          node-version: "14"
       - name: Install Linter dependencies
         run: npm install
       - name: Run Mega Linter
@@ -72,8 +71,8 @@ jobs:
           SPELL_MISSPELL_DISABLE_ERRORS: true
           SPELL_CSPELL_DISABLE_ERRORS: true
           COPYPASTE_JSCPD_DISABLE_ERRORS: true
-          LINTER_RULES_PATH: '.'
-          GROOVY_NPM_GROOVY_LINT_FILTER_REGEX_EXCLUDE: 'Jenkinsfile'
+          LINTER_RULES_PATH: "."
+          GROOVY_NPM_GROOVY_LINT_FILTER_REGEX_EXCLUDE: "Jenkinsfile"
           MARKDOWN_MARKDOWN_LINK_CHECK_DISABLE_ERRORS: true
 
   commit-messages:
@@ -85,4 +84,5 @@ jobs:
           fetch-depth: 0
       - uses: wagoid/commitlint-github-action@v4
         with:
-          failOnWarnings: true
+          configFile: .github/config/commitlint.config.js
+          failOnWarnings: false


### PR DESCRIPTION
## Description
What's changed, or what was fixed?

- Relax the commit message checks to not fail on inconsistent casing but only warn instead

## Issues Fixed
- Fixes #

## Housekeeping
(please check all that apply [x], do not edit the text)
- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.

## Full Repo Validation Required
(please check all that apply [x], do not edit the text)
- [ ] PR requires full pipeline run (Run for changes only by default).

**CC:** @apigee-devrel-reviewers
