### PR TITLE
fix: force token refresh in pineline.sh

### DIFF
--- a/references/auth-schemes/pipeline.sh
+++ b/references/auth-schemes/pipeline.sh
@@ -106,7 +106,7 @@ cat <<EOF >> "$SCRIPTPATH/edge.json"
 }
 EOF
 
-googleToken=$(gcloud auth print-access-token);
+googleToken="$(gcloud config config-helper --force-auth-refresh --format json | jq -r '.credential.access_token')";
 
 export PATH="$PATH:$SCRIPTPATH/../../tools/apigee-sackmesser/bin"
 

--- a/references/cicd-pipeline/pipeline.sh
+++ b/references/cicd-pipeline/pipeline.sh
@@ -71,7 +71,7 @@ docker run \
 
 echo "[INFO] CICD Pipeline for Apigee X (Jenkins)"
 
-TOKEN=$(gcloud auth print-access-token)
+TOKEN="$(gcloud config config-helper --force-auth-refresh --format json | jq -r '.credential.access_token')"
 
 docker run \
   -e APIGEE_USER="not-used" \

--- a/references/cicd-pipeline/pom.xml
+++ b/references/cicd-pipeline/pom.xml
@@ -75,8 +75,8 @@ limitations under the License.
 			<!-- Apigee X and hybrid -->
 			<id>googleapi</id>
 			<properties>
-				<apigee.plugin.version>2.3.1</apigee.plugin.version>
-				<apigee.config-plugin.version>2.3.0</apigee.config-plugin.version>
+				<apigee.plugin.version>2.3.5</apigee.plugin.version>
+				<apigee.config-plugin.version>2.4.4</apigee.config-plugin.version>
 				<apigee.hosturl>https://apigee.googleapis.com</apigee.hosturl>
 				<apigee.bearer>${token}</apigee.bearer> <!-- this takes precedence over service account file -->
 				<apigee.serviceaccount.file>${sa}</apigee.serviceaccount.file>

--- a/references/cicd-sharedflow-pipeline/pipeline.sh
+++ b/references/cicd-sharedflow-pipeline/pipeline.sh
@@ -19,7 +19,7 @@ set -x
 
 # Apigee X/hybrid
 
-TOKEN=$(gcloud auth print-access-token)
+TOKEN="$(gcloud config config-helper --force-auth-refresh --format json | jq -r '.credential.access_token')"
 
 # Deploy the sharedflow
 mvn clean install -Pgoogleapi -Dorg="$APIGEE_X_ORG" \

--- a/references/cicd-sharedflow-pipeline/pom.xml
+++ b/references/cicd-sharedflow-pipeline/pom.xml
@@ -52,7 +52,7 @@ limitations under the License.
 			<!-- Apigee Edge -->
 			<id>apigeeapi</id>
 			<properties>
-				<apigee.deploy.plugin.version>1.3.2</apigee.deploy.plugin.version>
+				<apigee.deploy.plugin.version>1.3.3</apigee.deploy.plugin.version>
 				<apigee.hosturl>https://api.enterprise.apigee.com</apigee.hosturl>
 				<apigee.authtype>oauth</apigee.authtype>
 				<apigee.tokenurl>https://login.apigee.com/oauth/token</apigee.tokenurl>
@@ -66,7 +66,7 @@ limitations under the License.
 			<!-- Apigee X and hybrid -->
 			<id>googleapi</id>
 			<properties>
-				<apigee.deploy.plugin.version>2.2.2</apigee.deploy.plugin.version>
+				<apigee.deploy.plugin.version>2.3.5</apigee.deploy.plugin.version>
 				<apigee.hosturl>https://apigee.googleapis.com</apigee.hosturl>
 				<apigee.bearer>${token}</apigee.bearer>
 				<apigee.serviceaccount.file>${file}</apigee.serviceaccount.file>

--- a/references/cicd-sharedflow-pipeline/test/integration/pom.xml
+++ b/references/cicd-sharedflow-pipeline/test/integration/pom.xml
@@ -56,8 +56,8 @@ limitations under the License.
 			<!-- Apigee Edge -->
 			<id>apigeeapi</id>
 			<properties>
-				<apigee.deploy.plugin.version>1.3.2</apigee.deploy.plugin.version>
-				<apigee.config.plugin.version>1.5.2</apigee.config.plugin.version>
+				<apigee.deploy.plugin.version>1.3.3</apigee.deploy.plugin.version>
+				<apigee.config.plugin.version>1.5.3</apigee.config.plugin.version>
 				<apigee.hosturl>https://api.enterprise.apigee.com</apigee.hosturl>
 				<apigee.authtype>oauth</apigee.authtype>
 				<apigee.tokenurl>https://login.apigee.com/oauth/token</apigee.tokenurl>
@@ -72,8 +72,8 @@ limitations under the License.
 			<!-- Apigee X and hybrid -->
 			<id>googleapi</id>
 			<properties>
-				<apigee.deploy.plugin.version>2.2.2</apigee.deploy.plugin.version>
-				<apigee.config.plugin.version>2.2.2</apigee.config.plugin.version>
+				<apigee.deploy.plugin.version>2.3.5</apigee.deploy.plugin.version>
+				<apigee.config.plugin.version>2.4.4</apigee.config.plugin.version>
 				<apigee.hosturl>https://apigee.googleapis.com</apigee.hosturl>
 				<apigee.bearer>${token}</apigee.bearer>
 				<apigee.serviceaccount.file>${file}</apigee.serviceaccount.file>

--- a/references/cloud-logging-shared-flow/pipeline.sh
+++ b/references/cloud-logging-shared-flow/pipeline.sh
@@ -18,7 +18,7 @@ set -e
 
 SCRIPTPATH=$( (cd "$(dirname "$0")" && pwd ))
 
-APIGEE_TOKEN=$(gcloud auth print-access-token);
+APIGEE_TOKEN="$(gcloud config config-helper --force-auth-refresh --format json | jq -r '.credential.access_token')";
 
 SA_EMAIL="cloud-log-writer@$APIGEE_X_ORG.iam.gserviceaccount.com"
 

--- a/references/cloud-run/pipeline.sh
+++ b/references/cloud-run/pipeline.sh
@@ -47,7 +47,7 @@ cp -r "$SCRIPTPATH/cloud-run-v0-template" "$SCRIPTPATH/cloud-run-v0"
 sed -i.bak "s|CLOUD_RUN_URL|$CLOUD_RUN_URL|g" "$SCRIPTPATH/cloud-run-v0/apiproxy/targets/default.xml"
 rm "$SCRIPTPATH/cloud-run-v0/apiproxy/targets/default.xml.bak"
 
-TOKEN=$(gcloud auth print-access-token)
+TOKEN="$(gcloud config config-helper --force-auth-refresh --format json | jq -r '.credential.access_token')"
 sackmesser deploy -d "$SCRIPTPATH/cloud-run-v0"  -t "$TOKEN" --deployment-sa "$SA_EMAIL"
 
 response=$(curl "https://${APIGEE_X_HOSTNAME}/cloud-run/v0")

--- a/references/common-shared-flows/deploy.sh
+++ b/references/common-shared-flows/deploy.sh
@@ -44,7 +44,7 @@ export PATH="$PATH:$SCRIPTPATH/../../tools/apigee-sackmesser/bin"
 
 for SF in $sf_to_deploy; do
   if [ "$apiversion" = "--googleapi" ]; then
-    APIGEE_TOKEN=$(gcloud auth print-access-token);
+    APIGEE_TOKEN="$(gcloud config config-helper --force-auth-refresh --format json | jq -r '.credential.access_token')";
     sackmesser deploy -d "$SF" "$apiversion" "$async_flag" \
       -t "$APIGEE_TOKEN" -o "$APIGEE_X_ORG" -e "$APIGEE_X_ENV" \
       --description "See Apigee DevRel references/common-shared-flows"
@@ -61,7 +61,7 @@ done
 
 if [ -n "$async_flag" ] && [ "$apiversion" = "--googleapi" ]; then
   for SF in $sf_to_deploy; do
-    APIGEE_TOKEN=$(gcloud auth print-access-token);
+    APIGEE_TOKEN="$(gcloud config config-helper --force-auth-refresh --format json | jq -r '.credential.access_token')";
     sackmesser await sharedflow "$(basename "$SF")" "$apiversion" \
       -t "$APIGEE_TOKEN" -o "$APIGEE_X_ORG" -e "$APIGEE_X_ENV"
   done

--- a/references/data-api/pipeline.sh
+++ b/references/data-api/pipeline.sh
@@ -49,7 +49,7 @@ done
 
 mv "$PROXY_DIR/apiproxy/proxy.xml" "$PROXY_DIR/apiproxy/$PROXY_NAME.xml"
 
-APIGEE_TOKEN=$(gcloud auth print-access-token);
+APIGEE_TOKEN="$(gcloud config config-helper --force-auth-refresh --format json | jq -r '.credential.access_token')"
 sackmesser deploy -o "$APIGEE_X_ORG" -e "$APIGEE_X_ENV" -d "$PROXY_DIR" -t "$APIGEE_TOKEN" --deployment-sa "$SA_EMAIL"
 
 TEST_BASE_URI="$APIGEE_X_HOSTNAME/london/v1" npm run test

--- a/references/data-converters-shared-flow/deploy.sh
+++ b/references/data-converters-shared-flow/deploy.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-APIGEE_TOKEN=$(gcloud auth print-access-token)
+APIGEE_TOKEN="$(gcloud config config-helper --force-auth-refresh --format json | jq -r '.credential.access_token')"
 
 ../../tools/apigee-sackmesser/bin/sackmesser deploy -d "." --googleapi \
         -t "$APIGEE_TOKEN" -o "$APIGEE_X_ORG" -e "$APIGEE_X_ENV"

--- a/references/dutch-healthcare/pipeline.sh
+++ b/references/dutch-healthcare/pipeline.sh
@@ -27,11 +27,13 @@ export APIGEE_TOKEN
 ARGS=$*
 SACKMESSER_ARGS="${ARGS:---googleapi}"
 
-sackmesser deploy \
-  -d healthcare-mock-v1 "$SACKMESSER_ARGS"
+APIGEE_TOKEN="$(gcloud config config-helper --force-auth-refresh --format json | jq -r '.credential.access_token')"
 
 sackmesser deploy \
-  -d healthcare-v1 "$SACKMESSER_ARGS"
+  -d healthcare-mock-v1 "$SACKMESSER_ARGS" -t "$APIGEE_TOKEN"
+
+sackmesser deploy \
+  -d healthcare-v1 "$SACKMESSER_ARGS" -t "$APIGEE_TOKEN"
 
 npm i --no-fund --prefix healthcare-v1
 TEST_BASEPATH='/healthcare/v1' TEST_HOST="$APIGEE_X_HOSTNAME" npm test --prefix healthcare-v1

--- a/references/dutch-healthcare/pipeline.sh
+++ b/references/dutch-healthcare/pipeline.sh
@@ -18,7 +18,7 @@ set -e
 
 SCRIPTPATH=$( (cd "$(dirname "$0")" && pwd ))
 
-APIGEE_TOKEN=$(gcloud auth print-access-token);
+APIGEE_TOKEN="$(gcloud config config-helper --force-auth-refresh --format json | jq -r '.credential.access_token')"
 export APIGEE_TOKEN
 
 # deploy shared flows

--- a/references/gcp-sa-auth-shared-flow/deploy.sh
+++ b/references/gcp-sa-auth-shared-flow/deploy.sh
@@ -47,7 +47,7 @@ if [ "$apiversion" = "--apigeeapi" ]; then
         --description "See Apigee DevRel references/common-shared-flows"
 else
     sed -i.bak "s/@ENV_NAME@/$APIGEE_X_ENV/g" "$SCRIPTPATH"/edge.json && rm "$SCRIPTPATH"/edge.json.bak
-    APIGEE_TOKEN=$(gcloud auth print-access-token)
+    APIGEE_TOKEN="$(gcloud config config-helper --force-auth-refresh --format json | jq -r '.credential.access_token')"
     sackmesser deploy -d "$SCRIPTPATH" "$apiversion" \
         -t "$APIGEE_TOKEN" -o "$APIGEE_X_ORG" -e "$APIGEE_X_ENV" -h "$APIGEE_X_HOSTNAME" \
         --description "See Apigee DevRel references/common-shared-flows"

--- a/references/gcp-sa-auth-shared-flow/pipeline.sh
+++ b/references/gcp-sa-auth-shared-flow/pipeline.sh
@@ -41,7 +41,7 @@ curl --fail "https://$APIGEE_ORG-$APIGEE_ENV.apigee.net/token-validation/v0/jwt"
 
 # Apigee X Pipeline
 "$SCRIPTPATH"/deploy.sh "$SCRIPTPATH/$SA_NAME-key.json" --googleapi
-APIGEE_TOKEN=$(gcloud auth print-access-token)
+APIGEE_TOKEN="$(gcloud config config-helper --force-auth-refresh --format json | jq -r '.credential.access_token')"
 sackmesser deploy --googleapi -d "$SCRIPTPATH"/test/token-validation \
   -t "$APIGEE_TOKEN" -o "$APIGEE_X_ORG" -e "$APIGEE_X_ENV" \
   -n token-validation-v0

--- a/references/identity-facade/pipeline.sh
+++ b/references/identity-facade/pipeline.sh
@@ -269,7 +269,7 @@ generate_authz_url() {
         CODE_CHALLENGE_METHOD=""
         CODE_CHALLENGE=""
     fi
-    
+
     printf "\n"
     printf "##########################\n"
     printf "#### Authorization URL ###\n"
@@ -350,7 +350,7 @@ fi
 
 if [ -z "$1" ] || [ "$1" = "--googleapi" ];then
     echo "[INFO] Deploying Identitiy facade to Google API (For X/hybrid)"
-    APIGEE_TOKEN=$(gcloud auth print-access-token);
+    APIGEE_TOKEN="$(gcloud config config-helper --force-auth-refresh --format json | jq -r '.credential.access_token')"
 
     if [ -z ${IDP_DISCOVERY_DOCUMENT+x} ];
     then

--- a/references/java-callout/pipeline.sh
+++ b/references/java-callout/pipeline.sh
@@ -23,6 +23,6 @@ TEST_HOST="$APIGEE_ORG-$APIGEE_ENV.apigee.net" npm test --prefix proxy-v1
 
 echo "Testing on Apigee X"
 mvn install -Papigee-x -Dapigee.env="$APIGEE_X_ENV" -Dapigee.org="$APIGEE_X_ORG" \
-  -Dapigee.bearer="$(gcloud auth print-access-token)" -B -ntp
+  -Dapigee.bearer="$(gcloud config config-helper --force-auth-refresh --format json | jq -r '.credential.access_token')" -B -ntp
 
  TEST_HOST="$APIGEE_X_HOSTNAME" npm test --prefix proxy-v1

--- a/references/java-callout/proxy-v1/pom.xml
+++ b/references/java-callout/proxy-v1/pom.xml
@@ -53,8 +53,8 @@ xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/
     <org.slf4j.simpleLogger.defaultLogLevel>info</org.slf4j.simpleLogger.defaultLogLevel>
     <project.root.dir>${basedir}</project.root.dir>
     <target.root.dir>${basedir}/target</target.root.dir>
-    <edge.apigee.plugin.version>1.3.2</edge.apigee.plugin.version>
-    <x.apigee.plugin.version>2.3.1</x.apigee.plugin.version>
+    <edge.apigee.plugin.version>1.3.3</edge.apigee.plugin.version>
+    <x.apigee.plugin.version>2.3.5</x.apigee.plugin.version>
   </properties>
   <!-- This is where you add the environment specific properties under various profile names -->
   <!-- For apigee.options, refer to "Advanced Configuration Options" under https://github.com/apigee/apigee-deploy-maven-plugin#pom-xml-sample -->

--- a/references/js-callout/pipeline.sh
+++ b/references/js-callout/pipeline.sh
@@ -29,7 +29,7 @@ sackmesser deploy --apigeeapi -d "$SCRIPTPATH" \
 (cd "$SCRIPTPATH" && TEST_HOST="$APIGEE_ORG-$APIGEE_ENV.apigee.net" npm run integration-test)
 
 echo "Testing on Apigee X"
-APIGEE_TOKEN=$(gcloud auth print-access-token);
+APIGEE_TOKEN="$(gcloud config config-helper --force-auth-refresh --format json | jq -r '.credential.access_token')"
 sackmesser deploy --googleapi -d "$SCRIPTPATH" \
   -t "$APIGEE_TOKEN" -o "$APIGEE_X_ORG" -e "$APIGEE_X_ENV" \
   -n js-callout-v1

--- a/references/kvm-admin-api/pipeline.sh
+++ b/references/kvm-admin-api/pipeline.sh
@@ -16,7 +16,7 @@
 
 set -e
 
-TOKEN=$(gcloud auth print-access-token)
+TOKEN="$(gcloud config config-helper --force-auth-refresh --format json | jq -r '.credential.access_token')"
 
 # Deploy the proxy
 mvn clean install -ntp -B -Pgoogleapi -Dorg="$APIGEE_X_ORG" -Denv="$APIGEE_X_ENV" \

--- a/references/kvm-admin-api/pom.xml
+++ b/references/kvm-admin-api/pom.xml
@@ -61,7 +61,7 @@ limitations under the License.
             <!-- Current Generation SaaS -->
             <id>apigeeapi</id>
             <properties>
-                <apigee.plugin.version>1.3.2</apigee.plugin.version>
+                <apigee.plugin.version>1.3.3</apigee.plugin.version>
                 <apigee.hosturl>https://api.enterprise.apigee.com</apigee.hosturl>
                 <apigee.authtype>oauth</apigee.authtype>
                 <apigee.username>${username}</apigee.username>
@@ -72,7 +72,7 @@ limitations under the License.
             <!-- Next Generation SaaS and hybrid -->
             <id>googleapi</id>
             <properties>
-                <apigee.plugin.version>2.2.2</apigee.plugin.version>
+                <apigee.plugin.version>2.3.5</apigee.plugin.version>
 				<apigee.hosturl>https://apigee.googleapis.com</apigee.hosturl>
                 <apigee.bearer>${token}</apigee.bearer> <!-- this takes precedence over service account file -->
                 <apigee.serviceaccount.file>${sa}</apigee.serviceaccount.file>

--- a/references/oauth-admin-api/pipeline.sh
+++ b/references/oauth-admin-api/pipeline.sh
@@ -17,7 +17,7 @@
 set -e
 
 SCRIPTPATH="$( cd "$(dirname "$0")" || exit >/dev/null 2>&1 ; pwd -P )"
-APIGEE_TOKEN=$(gcloud auth print-access-token)
+APIGEE_TOKEN="$(gcloud config config-helper --force-auth-refresh --format json | jq -r '.credential.access_token')"
 
 DEVELOPER_EMAIL='oauth-admin-pipeline@example.com'
 DEVELOPER_APP='oauth-admin-app'

--- a/references/product-recommendations/pipeline.sh
+++ b/references/product-recommendations/pipeline.sh
@@ -37,7 +37,7 @@ echo "Pipeline for product-recommendations - setup spanner"
 
 echo "Pipeline for product-recommendations - maven apigee install"
 # This performs end-to-end install, configuration and testing API.
-mvn -P eval clean install -Dbearer="$(gcloud auth print-access-token)" \
+mvn -P eval clean install -Dbearer="$(gcloud config config-helper --force-auth-refresh --format json | jq -r '.credential.access_token')" \
     -DapigeeOrg="$APIGEE_X_ORG" \
     -DapigeeEnv="$APIGEE_X_ENV" \
     -DenvGroupHostname="$APIGEE_X_HOSTNAME" \
@@ -52,13 +52,13 @@ if [ $? != 0 ]; then
 fi
 
 echo "Pipeline for product-recommendations - maven apigee clean"
-mvn -P eval process-resources -Dbearer="$(gcloud auth print-access-token)" \
+mvn -P eval process-resources -Dbearer="$(gcloud config config-helper --force-auth-refresh --format json | jq -r '.credential.access_token')" \
     -DapigeeOrg="$APIGEE_X_ORG" -DapigeeEnv="$APIGEE_X_ENV" -Dskip.integration=true \
     apigee-config:apps apigee-config:apiproducts apigee-config:developers -Dapigee.config.options=delete \
     apigee-enterprise:deploy -Dapigee.options=clean
 
 echo "Pipeline for product-recommendations - cleanup bigquery"
-./cleanup_bigquery.sh			
+./cleanup_bigquery.sh
 
 echo "Pipeline for product-recommendations - cleanup spanner"
 ./cleanup_spanner.sh

--- a/references/product-recommendations/pom.xml
+++ b/references/product-recommendations/pom.xml
@@ -163,7 +163,7 @@
 			<plugin>
 				<groupId>io.apigee.build-tools.enterprise4g</groupId>
 				<artifactId>apigee-edge-maven-plugin</artifactId>
-				<version>2.2.2</version>
+				<version>2.3.5</version>
 				<executions>
 					<execution>
 						<id>configure-bundle-step</id>

--- a/references/proxy-template/generate-proxy.sh
+++ b/references/proxy-template/generate-proxy.sh
@@ -107,7 +107,7 @@ fi
 if [ -z "$1" ] || [ "$1" = "--googleapi" ];then
 
     # get apigee token
-    APIGEE_TOKEN=$(gcloud auth print-access-token);
+    APIGEE_TOKEN="$(gcloud config config-helper --force-auth-refresh --format json | jq -r '.credential.access_token')"
 
     # create target server if does not exist
     response=$(curl -X GET \

--- a/references/proxy-template/pipeline.sh
+++ b/references/proxy-template/pipeline.sh
@@ -18,7 +18,7 @@ set -e
 SCRIPTPATH="$( cd "$(dirname "$0")" || exit >/dev/null 2>&1 ; pwd -P )"
 
 # default proxy name and version
-PROXY=example 
+PROXY=example
 VERSION=v1
 
 # default target server URL
@@ -71,7 +71,7 @@ if [ -z "$1" ] || [ "$1" = "--googleapi" ];then
 
     # generate the proxy configuration
     echo "[INFO] Creating Proxy template and Target Server configuration"
-    
+
     PROXY="$PROXY" \
     VERSION="$VERSION" \
     VHOST="$VHOST" \
@@ -81,7 +81,7 @@ if [ -z "$1" ] || [ "$1" = "--googleapi" ];then
     echo "[INFO] Deploying Proxy Template to Google API (For X/hybrid)"
 
     # get apigee token
-    APIGEE_TOKEN=$(gcloud auth print-access-token);
+    APIGEE_TOKEN="$(gcloud config config-helper --force-auth-refresh --format json | jq -r '.credential.access_token')";
 
     # deploy Apigee artifacts: proxy and target server
     sackmesser deploy --googleapi \

--- a/references/proxy-template/pipeline.sh
+++ b/references/proxy-template/pipeline.sh
@@ -33,7 +33,7 @@ TARGET_URL="${TARGET_URL:-"$DEFAULT_TARGET_URL"}"
 if [ -z "$1" ] || [ "$1" = "--apigeeapi" ];then
 
     # deploy all common shared flows
-    (cd "$SCRIPTPATH"/../common-shared-flows && sh deploy.sh all --apigeeapi)
+    (cd "$SCRIPTPATH"/../common-shared-flows && sh deploy.sh all --apigeeapi --async)
 
     # clean up
     rm -rf "$SCRIPTPATH"/"$PROXY"-"$VERSION"
@@ -64,7 +64,7 @@ fi
 if [ -z "$1" ] || [ "$1" = "--googleapi" ];then
 
     # deploy all common shared flows
-    (cd "$SCRIPTPATH"/../common-shared-flows && sh deploy.sh all --googleapi)
+    (cd "$SCRIPTPATH"/../common-shared-flows && sh deploy.sh all --googleapi --async)
 
     # clean up
     rm -rf "$SCRIPTPATH"/"$PROXY"-"$VERSION"

--- a/references/recaptcha-enterprise/cleanup.sh
+++ b/references/recaptcha-enterprise/cleanup.sh
@@ -16,7 +16,7 @@
 PROJECT_ID=$(gcloud config get-value project)
 
 # Get an Apigee token
-APIGEE_TOKEN=$(gcloud auth print-access-token);
+APIGEE_TOKEN="$(gcloud config config-helper --force-auth-refresh --format json | jq -r '.credential.access_token')"
 
 # delete developer and related artifacts (client apps)
 echo "[INFO] Deleting recaptcha enterprise developer and apps"

--- a/references/recaptcha-enterprise/pipeline.sh
+++ b/references/recaptcha-enterprise/pipeline.sh
@@ -206,7 +206,7 @@ export IS_RECAPTCHA_MOCK_ENABLED
 envsubst < "$SCRIPTPATH"/templates/AM-SetReCaptchaMock.template.xml > "$SCRIPTPATH"/sf-recaptcha-enterprise-v1/sharedflowbundle/policies/AM-SetReCaptchaMock.xml
 
 echo "[INFO] Deploying reCAPTCHA enterprise reference to Google API (For X/hybrid)"
-APIGEE_TOKEN=$(gcloud auth print-access-token);
+APIGEE_TOKEN="$(gcloud config config-helper --force-auth-refresh --format json | jq -r '.credential.access_token')";
 
 SA_EMAIL="apigee-recaptcha-enterprise-sa@$APIGEE_X_ORG.iam.gserviceaccount.com"
 
@@ -264,7 +264,7 @@ if [ "$IS_RECAPTCHA_MOCK_ENABLED" = "true" ];then
         --data "{ \"apiProducts\": [\"RecaptchaEnterprise\"] }" \
         https://apigee.googleapis.com/v1/organizations/"$APIGEE_X_ORG"/developers/janedoe@example.com/apps/app-recaptcha-enterprise/keys/"$TEST_APP_CONSUMER_KEY"
 
-    
+
     cd "$SCRIPTPATH" && npm i --no-fund && TEST_HOST="$APIGEE_X_HOSTNAME" npm run test
 
 else
@@ -277,7 +277,7 @@ else
     # Generate 2 reCAPTCHA sitekeys: - Always 1 (score: 1) & Always 0 (score: 0)
     TMP0=$(gcloud recaptcha keys create --testing-score=0.0 --web --allow-all-domains --display-name="Always 0" --integration-type=score --format=json | jq -r .name)
     SITEKEY_ALWAYS_0=$(echo "$TMP0" | cut -d'/' -f 4)
-    
+
     TMP1=$(gcloud recaptcha keys create --testing-score=1.0 --web --allow-all-domains --display-name="Always 1" --integration-type=score --format=json | jq -r .name)
     SITEKEY_ALWAYS_1=$(echo "$TMP1" | cut -d'/' -f 4)
 

--- a/references/recaptcha-enterprise/pipeline.sh
+++ b/references/recaptcha-enterprise/pipeline.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # Copyright 2022 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -206,7 +206,8 @@ export IS_RECAPTCHA_MOCK_ENABLED
 envsubst < "$SCRIPTPATH"/templates/AM-SetReCaptchaMock.template.xml > "$SCRIPTPATH"/sf-recaptcha-enterprise-v1/sharedflowbundle/policies/AM-SetReCaptchaMock.xml
 
 echo "[INFO] Deploying reCAPTCHA enterprise reference to Google API (For X/hybrid)"
-APIGEE_TOKEN="$(gcloud config config-helper --force-auth-refresh --format json | jq -r '.credential.access_token')";
+
+token() { echo -n "$(gcloud config config-helper --force-auth-refresh --format json | jq -r '.credential.access_token')"; }
 
 SA_EMAIL="apigee-recaptcha-enterprise-sa@$APIGEE_X_ORG.iam.gserviceaccount.com"
 
@@ -218,12 +219,12 @@ fi
 
 # Create DataCollectors on Apigee for custom analytics data reports (risk score and token validity)
 curl --silent -X POST \
-    -H "Authorization: Bearer $APIGEE_TOKEN" -H "Accept: application/json" -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $(token)" -H "Accept: application/json" -H "Content-Type: application/json" \
     --data '{"name":"dc_riskScore","description":"data collection of Enterprise reCAPTCHA risk score","type":"FLOAT"}' \
     https://apigee.googleapis.com/v1/organizations/"$APIGEE_X_ORG"/datacollectors || true
 
 curl --silent -X POST \
-    -H "Authorization: Bearer $APIGEE_TOKEN" -H "Accept: application/json" -H "Content-Type: application/json" \
+    -H "Authorization: Bearer $(token)" -H "Accept: application/json" -H "Content-Type: application/json" \
     --data '{"name":"dc_tokenValidity","description":"data collection of Enterprise reCAPTCHA token validity","type":"STRING"}' \
     https://apigee.googleapis.com/v1/organizations/"$APIGEE_X_ORG"/datacollectors || true
 
@@ -239,7 +240,7 @@ if [ "$IS_RECAPTCHA_MOCK_ENABLED" = "true" ];then
     sackmesser deploy --googleapi \
         -o "$APIGEE_X_ORG" \
         -e "$APIGEE_X_ENV" \
-        -t "$APIGEE_TOKEN" \
+        -t "$(token)" \
         -h "$APIGEE_X_HOSTNAME" \
         -d "$SCRIPTPATH"/sf-recaptcha-enterprise-v1 \
         --deployment-sa "$SA_EMAIL"
@@ -248,19 +249,19 @@ if [ "$IS_RECAPTCHA_MOCK_ENABLED" = "true" ];then
     sackmesser deploy --googleapi \
         -o "$APIGEE_X_ORG" \
         -e "$APIGEE_X_ENV" \
-        -t "$APIGEE_TOKEN" \
+        -t "$(token)" \
         -h "$APIGEE_X_HOSTNAME" \
         -d "$SCRIPTPATH"/recaptcha-data-proxy-v1
 
     # set developer app ('app-recaptcha-enterprise') credentials
     curl --fail --silent -X POST \
-        -H "Authorization: Bearer $APIGEE_TOKEN" -H "Content-Type:application/json" \
+        -H "Authorization: Bearer $(token)" -H "Content-Type:application/json" \
         --data "{ \"consumerKey\": \"$TEST_APP_CONSUMER_KEY\", \"consumerSecret\": \"$TEST_APP_CONSUMER_SECRET\" }" \
         https://apigee.googleapis.com/v1/organizations/"$APIGEE_X_ORG"/developers/janedoe@example.com/apps/app-recaptcha-enterprise/keys/create
 
     # Set Recaptcha Enterprise product for developer app 'app-recaptcha-enterprise'
     curl --fail --silent -X POST \
-        -H "Authorization: Bearer $APIGEE_TOKEN" -H "Content-Type:application/json" \
+        -H "Authorization: Bearer $(token)" -H "Content-Type:application/json" \
         --data "{ \"apiProducts\": [\"RecaptchaEnterprise\"] }" \
         https://apigee.googleapis.com/v1/organizations/"$APIGEE_X_ORG"/developers/janedoe@example.com/apps/app-recaptcha-enterprise/keys/"$TEST_APP_CONSUMER_KEY"
 
@@ -288,7 +289,7 @@ else
     sackmesser deploy --googleapi \
         -o "$APIGEE_X_ORG" \
         -e "$APIGEE_X_ENV" \
-        -t "$APIGEE_TOKEN" \
+        -t "$(token)" \
         -h "$APIGEE_X_HOSTNAME" \
         -d "$SCRIPTPATH"/sf-recaptcha-enterprise-v1 \
         --deployment-sa "$SA_EMAIL"
@@ -297,7 +298,7 @@ else
     sackmesser deploy --googleapi \
         -o "$APIGEE_X_ORG" \
         -e "$APIGEE_X_ENV" \
-        -t "$APIGEE_TOKEN" \
+        -t "$(token)" \
         -h "$APIGEE_X_HOSTNAME" \
         -d "$SCRIPTPATH"/recaptcha-data-proxy-v1
 
@@ -305,7 +306,7 @@ else
     sackmesser deploy --googleapi \
         -o "$APIGEE_X_ORG" \
         -e "$APIGEE_X_ENV" \
-        -t "$APIGEE_TOKEN" \
+        -t "$(token)" \
         -h "$APIGEE_X_HOSTNAME" \
         -d "$SCRIPTPATH"/recaptcha-deliver-token-v1
 

--- a/references/southbound-mtls/pipeline.sh
+++ b/references/southbound-mtls/pipeline.sh
@@ -48,7 +48,7 @@ TEST_HOST="$APIGEE_ORG-$APIGEE_ENV.apigee.net"
 
 # Apigee X
 
-APIGEE_TOKEN=$(gcloud auth print-access-token);
+APIGEE_TOKEN="$(gcloud config config-helper --force-auth-refresh --format json | jq -r '.credential.access_token')";
 
 cp "$SCRIPTPATH"/edge.template.json "$SCRIPTPATH"/edge.json
 sed -i.bak "s/@ENV_NAME@/$APIGEE_X_ENV/g" "$SCRIPTPATH"/edge.json && rm "$SCRIPTPATH"/edge.json.bak

--- a/references/threat-protect/pipeline.sh
+++ b/references/threat-protect/pipeline.sh
@@ -37,7 +37,7 @@ fi
 
 if [ -z "$1" ] || [ "$1" = "--googleapi" ];then
     echo "[INFO] Deploying Identitiy facade to Google API (For X/hybrid)"
-    APIGEE_TOKEN=$(gcloud auth print-access-token);
+    APIGEE_TOKEN="$(gcloud config config-helper --force-auth-refresh --format json | jq -r '.credential.access_token')";
 
     sackmesser deploy --googleapi -o "$APIGEE_X_ORG" -e "$APIGEE_X_ENV" -t "$APIGEE_TOKEN" -d "$SCRIPTPATH"
     cd "$SCRIPTPATH" && npm i --no-fund && TEST_HOST="$APIGEE_X_HOSTNAME" npm run test

--- a/tools/apigee-envoy-quickstart/pipeline.sh
+++ b/tools/apigee-envoy-quickstart/pipeline.sh
@@ -39,7 +39,7 @@ printf "Running edge envoy cleanup"
 ./aekitctl.sh --type standalone-apigee-envoy --action delete --platform edge
 
 export APIGEE_PROJECT_ID="$APIGEE_X_ORG"
-TOKEN=$(gcloud auth print-access-token);
+TOKEN="$(gcloud config config-helper --force-auth-refresh --format json | jq -r '.credential.access_token')";
 export TOKEN
 
 printf "Running X envoy cleanup"

--- a/tools/apigee-sackmesser/bin/sackmesser
+++ b/tools/apigee-sackmesser/bin/sackmesser
@@ -132,7 +132,7 @@ if [[ -z "$apiversion" ]]; then
 fi
 
 if [ "$apiversion" = "google" ];then
-    export token=${token:-$APIGEE_TOKEN}
+    export token=${token:-"$(gcloud config config-helper --force-auth-refresh --format json | jq -r '.credential.access_token')"}
     export organization=${organization:-$APIGEE_X_ORG}
     export environment=${environment:-$APIGEE_X_ENV}
     export hostname=${hostname:-$APIGEE_X_HOSTNAME}
@@ -150,11 +150,12 @@ if [[ -z "$token" && (-z "$username"  || -z "$password") ]]; then
     exit 1
 fi
 
-if [[ -z "$token" && "$apiversion" = "apigee" && "$opdk" = "T" ]]; then
+if [[ -z "$token" && "$apiversion" = "apigee" ]]; then
+  if [[ "$opdk" = "T" ]]; then
     logdebug "Getting Apigee Basic Auth token for user $username"
-    token=`echo -n $username:$password | base64`
-    export $token
-elif [[ -z "$token" && "$apiversion" = "apigee" ]]; then
+    token=$(echo -n "$username:$password" | base64)
+    export token
+  else
     if [ -z "$mfa" ]; then MFA=""; else MFA="?mfa_token=$mfa"; fi
     logdebug "Getting Apigee OAuth2 token for user $username"
     response=$(curl -fsS -H "Content-Type:application/x-www-form-urlencoded;charset=utf-8" \
@@ -166,8 +167,7 @@ elif [[ -z "$token" && "$apiversion" = "apigee" ]]; then
       --data "grant_type=password")
     token=$(echo "$response" | jq -r '.access_token')
     export token
-elif [ "$apiversion" = "apigee" ]; then
-    export token=${token:-$APIGEE_TOKEN}
+  fi
 fi
 
 logdebug "Apigee OAuth2 (note: Basic Auth for Apigee Private Cloud [OPDK]) access token: ${token:0:8}..."

--- a/tools/apigee-sackmesser/cmd/deploy/deploy.sh
+++ b/tools/apigee-sackmesser/cmd/deploy/deploy.sh
@@ -63,7 +63,6 @@ if [ -f "$temp_folder"/edge.json ]; then
     loginfo "Preparing config $temp_folder/edge.json"
     export config_action='update'
     export config_file_path="$temp_folder"/edge.json
-    kvms=$(jq --arg APIGEE_ENV "$environment" -c '.envConfig[$APIGEE_ENV].kvms[]? | .' < "$temp_folder"/edge.json)
 
     if [ "$(jq '.orgConfig | has("importKeys")' "$temp_folder/edge.json")" = "true" ]; then
         loginfo "Found key import entry in file: $temp_folder/edge.json"
@@ -76,45 +75,10 @@ if [ -d "$temp_folder"/resources/edge ]; then
     export config_action='update'
     export config_dir_path="$temp_folder"/resources/edge
 
-    if [ -f "$temp_folder/resources/edge/env/$environment"/kvms.json ]; then
-        kvms=$(jq -c '.[] | .' < "$temp_folder/resources/edge/env/$environment"/kvms.json)
-    fi
-
     if [ -f "$temp_folder"/resources/edge/org/importKeys.json ]; then
         loginfo "Found key import file: $temp_folder/resources/edge/org/importKeys.json"
         import_keys_phase='install'
     fi
-fi
-
-if [ "$apiversion" = "google" ] && [ -n "$kvms" ]; then
-    echo "$kvms" | while read -r line; do
-        kvm=$(echo "$line" | jq -c 'del(.entry)')
-        kvmname=$(echo "$kvm" | jq -r '.name')
-        loginfo "X/hybrid patch: adding kvm: $kvmname"
-        curl -X POST --fail "https://apigee.googleapis.com/v1/organizations/$organization/environments/$environment/keyvaluemaps" \
-            -H "Authorization: Bearer $token" \
-            -H "Content-Type: application/json" \
-            --data "$kvm" || logwarn "failed to create KVM. Assuming it already exists"
-
-        KVM_ADMIN_STATUS=$(curl -s -o /dev/null -w "%{http_code}" -H "Authorization: Bearer $token" "https://apigee.googleapis.com/v1/organizations/$organization/environments/$environment/apis/kvm-admin-v1/deployments")
-
-        loginfo "kvm admin status $KVM_ADMIN_STATUS"
-
-        if [ "$KVM_ADMIN_STATUS" != "200" ];then
-            loginfo "creating kvm admin proxy"
-            "$SCRIPT_FOLDER/../../bin/sackmesser" deploy --googleapi -d "$SCRIPT_FOLDER/../../../../references/kvm-admin-api" -t "$token" \
-                -o "$organization" -e "$environment"
-        fi
-
-        echo "$line" | jq -c  '.entry[]? | .' | while read -r kvmentry; do
-            kvmentry=$(echo "$kvmentry" | jq '.["key"]=.name | del(.name)')
-            loginfo "adding entry: $(echo "$kvmentry" | jq '.key')"
-            curl -s -X POST -k --fail "https://$hostname/kvm-admin/v1/organizations/$organization/environments/$environment/keyvaluemaps/$kvmname/entries" \
-                -H "Authorization: Bearer $token" \
-                -H "Content-Type: application/json" \
-                --data "$kvmentry" > /dev/null || ( logfatal "failed to add entry to KVM: https://$hostname/kvm-admin/v1/organizations/$organization/environments/$environment/keyvaluemaps/$kvmname" && exit 1 )
-        done
-    done
 fi
 
 skip_deployment=true #skip maven deploy unless bundle contains proxy or shared flow

--- a/tools/apigee-sackmesser/cmd/deploy/deploy.sh
+++ b/tools/apigee-sackmesser/cmd/deploy/deploy.sh
@@ -182,15 +182,11 @@ if [ "$debug" = "T" ]; then
     MVN_DEBUG="-X"
 fi
 
-if [ "$MVN_REDUCE_LOGS" = "T" ]; then
-    MVN_NTP="-ntp"
-fi
-
 if [ "$apiversion" = "google" ]; then
     # install for apigee x/hybrid
     cp "$SCRIPT_FOLDER/pom-hybrid.xml" "$temp_folder/pom.xml"
     logdebug "Deploy to apigee.googleapis.com"
-    (cd "$temp_folder" && mvn install -B $MVN_DEBUG $MVN_NTP \
+    (cd "$temp_folder" && mvn install -B $MVN_DEBUG \
         -Dapitype="${api_type:-apiproxy}" \
         -Dorg="$organization" \
         -Denv="$environment" \
@@ -209,7 +205,7 @@ elif [ "$apiversion" = "apigee" ]; then
     cp "$SCRIPT_FOLDER/pom-edge.xml" "$temp_folder/pom.xml"
     logdebug "Deploy to Edge API"
     sed -i.bak "s|<artifactId>.*</artifactId><!--used-by-edge-->|<artifactId>$bundle_name<\/artifactId>|g" "$temp_folder"/pom.xml && rm "$temp_folder"/pom.xml.bak
-    (cd "$temp_folder" && mvn install -B $MVN_DEBUG $MVN_NTP \
+    (cd "$temp_folder" && mvn install -B $MVN_DEBUG \
         -Dapitype="${api_type:-apiproxy}" \
         -Dorg="$organization" \
         -Denv="$environment" \

--- a/tools/apigee-sackmesser/cmd/deploy/pom-edge.xml
+++ b/tools/apigee-sackmesser/cmd/deploy/pom-edge.xml
@@ -42,8 +42,8 @@ limitations under the License.
 	</repositories>
 
 	<properties>
-		<apigee.plugin.version>1.3.2</apigee.plugin.version>
-		<apigee.config-plugin.version>1.5.2</apigee.config-plugin.version>
+		<apigee.plugin.version>1.3.3</apigee.plugin.version>
+		<apigee.config-plugin.version>1.5.3</apigee.config-plugin.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 		<org.slf4j.simpleLogger.defaultLogLevel>info</org.slf4j.simpleLogger.defaultLogLevel>

--- a/tools/apigee-sackmesser/cmd/deploy/pom-hybrid.xml
+++ b/tools/apigee-sackmesser/cmd/deploy/pom-hybrid.xml
@@ -52,8 +52,8 @@ limitations under the License.
 		<apigee.apiversion>v1</apigee.apiversion>
 		<apigee.org>${org}</apigee.org>
 		<apigee.env>${env}</apigee.env>
-		<apigee.plugin.version>2.2.2</apigee.plugin.version>
-		<apigee.config-plugin.version>2.2.2</apigee.config-plugin.version>
+		<apigee.plugin.version>2.3.5</apigee.plugin.version>
+		<apigee.config-plugin.version>2.4.4</apigee.config-plugin.version>
 		<apigee.deploy.skip>false</apigee.deploy.skip>
 		<apigee.hosturl>https://${baseuri}</apigee.hosturl>
 		<apigee.bearer>${token}</apigee.bearer>

--- a/tools/apigee-sackmesser/pipeline.sh
+++ b/tools/apigee-sackmesser/pipeline.sh
@@ -22,7 +22,7 @@ SCRIPT_FOLDER=$( (cd "$(dirname "$0")" && pwd ))
 "$SCRIPT_FOLDER"/build.sh -t apigee-sackmesser
 
 PATH="$PATH:$SCRIPT_FOLDER/bin"
-APIGEE_X_TOKEN=$(gcloud auth print-access-token)
+APIGEE_X_TOKEN="$(gcloud config config-helper --force-auth-refresh --format json | jq -r '.credential.access_token')"
 unset APIGEE_TOKEN
 
 # Test Sackmesser Deploy

--- a/tools/apigee-sackmesser/test/sackmesser-example/resources/edge/org/kvms.json
+++ b/tools/apigee-sackmesser/test/sackmesser-example/resources/edge/org/kvms.json
@@ -1,10 +1,22 @@
 [
   {
     "name": "kvmtestmap",
-    "encrypted": "true"
+    "encrypted": "true",
+    "entry": [
+      {
+        "name": "foo",
+        "value": "001"
+      }
+    ]
   },
   {
     "name": "org-kvm",
-    "encrypted": "true"
+    "encrypted": "true",
+    "entry": [
+      {
+        "name": "bar",
+        "value": "002"
+      }
+    ]
   }
 ]

--- a/tools/endpoints-oas-importer/pipeline.sh
+++ b/tools/endpoints-oas-importer/pipeline.sh
@@ -31,7 +31,7 @@ echo "Generating the proxy from an OAS"
 "$SCRIPTPATH/import-endpoints.sh" --oas ./examples/openapi_test.yaml -b /headers -n oas-import-headers -q
 
 echo "Deploying the generated proxy"
-APIGEE_TOKEN=$(gcloud auth print-access-token)
+APIGEE_TOKEN="$(gcloud config config-helper --force-auth-refresh --format json | jq -r '.credential.access_token')"
 sackmesser deploy --googleapi -d "$SCRIPTPATH"/generated/oas-import-headers \
   -t "$APIGEE_TOKEN" -o "$APIGEE_X_ORG" -e "$APIGEE_X_ENV" \
   -n oas-import-headers
@@ -47,7 +47,7 @@ echo "Generating the proxy from an OAS"
 "$SCRIPTPATH/import-endpoints.sh" --oas ./examples/openapi_test.json -b /ip -n oas-import-ip -q
 
 echo "Deploying the generated proxy"
-APIGEE_TOKEN=$(gcloud auth print-access-token)
+APIGEE_TOKEN="$(gcloud config config-helper --force-auth-refresh --format json | jq -r '.credential.access_token')"
 sackmesser deploy --googleapi -d "$SCRIPTPATH"/generated/oas-import-ip \
   -t "$APIGEE_TOKEN" -o "$APIGEE_X_ORG" -e "$APIGEE_X_ENV" \
   -n oas-import-ip

--- a/tools/pipeline-runner/Dockerfile
+++ b/tools/pipeline-runner/Dockerfile
@@ -35,8 +35,8 @@ RUN apk add --no-cache \
   ca-certificates \
   ttf-freefont
 
-# Reduce nighly log (requires maven 3.6.1+)
-ENV MVN_REDUCE_LOGS="T"
+# Reduce nighly log (note: -ntp requires maven 3.6.1+)
+RUN alias mvn='mvn -ntp'
 
 # install claat
 RUN wget -qO- https://github.com/googlecodelabs/tools/releases/download/v2.2.4/claat-linux-amd64 > /usr/local/bin/claat

--- a/tools/pipeline-runner/cloudbuild.yaml
+++ b/tools/pipeline-runner/cloudbuild.yaml
@@ -63,7 +63,7 @@ steps:
     args:
       - "-c"
       - |-
-        max_duration=6960 # cloud build timeout minus 4m
+        max_duration=8760 # cloud build timeout minus 4m
         if [ -n "$_PR_NUMBER" ]; then
           FULL_PIPELINE_REQUIRED=$(curl "https://api.github.com/repos/$_REPO_GH_ISSUE/issues/$_PR_NUMBER" | jq '.body |= ascii_downcase | .body | contains("[x] pr requires full pipeline run")' )
           PROJECTS=$(list-repo-changes.sh)
@@ -140,7 +140,7 @@ availableSecrets:
 options:
   machineType: 'E2_HIGHCPU_8'
   logging: GCS_ONLY
-timeout: 7200s # 120min (needs to be updated with max_duration of pipeline)
+timeout: 9000s # 120min (needs to be updated with max_duration of pipeline)
 images: ['gcr.io/$PROJECT_ID/devrel-pipeline:latest']
 substitutions:
   _APIGEE_ORG: my-org


### PR DESCRIPTION
## Description
What's changed, or what was fixed?

- force token refresh because the `gcloud auth print-access-token` might return a token that expires during the long runnning maven deploy sessions. 

## Issues Fixed
- Fixes #611 

## Housekeeping
(please check all that apply [x], do not edit the text)
- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.

## Full Repo Validation Required
(please check all that apply [x], do not edit the text)
- [ ] PR requires full pipeline run (Run for changes only by default).

**CC:** @apigee-devrel-reviewers
