### PR TITLE
chore: remove firewalls in the quickstart cluster cleanup

### DIFF
--- a/tools/hybrid-quickstart/README.md
+++ b/tools/hybrid-quickstart/README.md
@@ -141,8 +141,14 @@ Apigee hybrid organization and runtime. This typically takes between 15 and
 
 ## Clean up
 
-Delete the runtime resources (without deleting the Apigee Organization) to avoid
-paying for unused GKE clusters.
+This tool includes a script to automatically the Apigee hybrid runtime
+resources (without deleting the Apigee Organization) to avoid paying
+for unused GKE clusters.
+
+**Note:** The cleanup script is designed to run on a standalone GCP project.
+If you provisioned the quickstart in a GCP project with other resources
+consider deleting the GCP resources manually to avoid accidentally deleting
+the resources that are needed by other services.
 
 ```sh
 ./destroy-runtime-gke.sh

--- a/tools/hybrid-quickstart/README.md
+++ b/tools/hybrid-quickstart/README.md
@@ -141,9 +141,8 @@ Apigee hybrid organization and runtime. This typically takes between 15 and
 
 ## Clean up
 
-This tool includes a script to automatically the Apigee hybrid runtime
-resources (without deleting the Apigee Organization) to avoid paying
-for unused GKE clusters.
+This tool includes a script to automatically clean up the Apigee hybrid
+runtime resources (without deleting the Apigee Organization).
 
 **Note:** The cleanup script is designed to run on a standalone GCP project.
 If you provisioned the quickstart in a GCP project with other resources

--- a/tools/hybrid-quickstart/destroy-runtime-gke.sh
+++ b/tools/hybrid-quickstart/destroy-runtime-gke.sh
@@ -86,6 +86,18 @@ for mcrt in $(gcloud compute ssl-certificates list --format="value(name)" --filt
    gcloud compute ssl-certificates delete "$mcrt" -q
 done
 
+for firewall in $(gcloud compute firewall-rules list --filter="name~^k8s-fw-" --format='get(name)'); do
+   gcloud compute  firewall-rules delete "$firewall" -q
+done
+
+for hcfirewall in $(gcloud compute firewall-rules list --filter='name~-hc$' --format='get(name)'); do
+   gcloud compute  firewall-rules delete "$hcfirewall" -q
+done
+
+for firewall in $(gcloud compute firewall-rules list --filter="name~^$NETWORK" --format='get(name)'); do
+   gcloud compute  firewall-rules delete "$firewall" -q
+done
+
 if [ -n "$(gcloud compute routers nats list --region "$REGION" --router "rt-$REGION" --format json --format='get(name)')" ]; then
    gcloud compute routers nats delete "apigee-nat-$REGION" --router "rt-$REGION"  -q
 fi


### PR DESCRIPTION
## Description
What's changed, or what was fixed?

- clean up firewalls for the GKE cluster (usually removed automatically but might linger around if the cleanup got interrupted)
- Note on cleanup script in the main README

## Issues Fixed
- Fixes #626

## Housekeeping
(please check all that apply [x], do not edit the text)
- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.

## Full Repo Validation Required
(please check all that apply [x], do not edit the text)
- [ ] PR requires full pipeline run (Run for changes only by default).

**CC:** @apigee-devrel-reviewers
