### PR TITLE
fix: removing deprecated API from hybrid-quickstart

### DIFF
--- a/tools/hybrid-quickstart/steps.sh
+++ b/tools/hybrid-quickstart/steps.sh
@@ -204,7 +204,6 @@ enable_all_apis() {
     logging.googleapis.com \
     meshca.googleapis.com \
     meshconfig.googleapis.com \
-    meshtelemetry.googleapis.com \
     monitoring.googleapis.com \
     pubsub.googleapis.com \
     stackdriver.googleapis.com \


### PR DESCRIPTION
## Description
- Removed `meshtelemetry.googleapis.com` [(deprecated)](https://cloud.google.com/service-mesh/v1.15/docs/troubleshooting/troubleshoot-installation#failed_installation_due_to_missing_meshtelemetrygoogleapiscom_api) from list of APIs enabled for `references/hybrid-quickstart`

## Issues Fixed
- Fixes `#662` (not smart-linking to avoid auto-close of issue) 

## Housekeeping
(please check all that apply [x], do not edit the text)
- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.

## Full Repo Validation Required
(please check all that apply [x], do not edit the text)
- [ ] PR requires full pipeline run (Run for changes only by default).

**CC:** @apigee-devrel-reviewers
