### PR TITLE
feat: bump hybrid 1.9.2 plus local httpbin demo service

### DIFF
--- a/tools/hybrid-quickstart/example-proxy/apiproxy/targets/default.xml
+++ b/tools/hybrid-quickstart/example-proxy/apiproxy/targets/default.xml
@@ -26,6 +26,6 @@
     <Response/>
   </PostFlow>
   <HTTPTargetConnection>
-    <URL>https://httpbin.org</URL>
+    <URL>http://httpbin.example-backend.svc.cluster.local</URL>
   </HTTPTargetConnection>
 </TargetEndpoint>

--- a/tools/hybrid-quickstart/example-proxy/resources.yaml
+++ b/tools/hybrid-quickstart/example-proxy/resources.yaml
@@ -1,0 +1,40 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: example-backend
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: httpbin
+  namespace: example-backend
+spec:
+  selector:
+    matchLabels:
+      app: httpbin
+  template:
+    metadata:
+      labels:
+        app: httpbin
+    spec:
+      containers:
+      - name: httpbin
+        image: docker.io/kennethreitz/httpbin
+        resources:
+          limits:
+            memory: "64Mi"
+            cpu: "100m"
+        ports:
+        - containerPort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: httpbin
+  namespace: example-backend
+spec:
+  selector:
+    app: httpbin
+  ports:
+  - port: 80
+    targetPort: 80

--- a/tools/hybrid-quickstart/steps.sh
+++ b/tools/hybrid-quickstart/steps.sh
@@ -64,9 +64,9 @@ set_config_params() {
     export GKE_CLUSTER_NAME=${GKE_CLUSTER_NAME:-apigee-hybrid}
     export GKE_CLUSTER_MACHINE_TYPE=${GKE_CLUSTER_MACHINE_TYPE:-e2-standard-4}
     echo "- GKE Node Type $GKE_CLUSTER_MACHINE_TYPE"
-    export APIGEE_HYBRID_VERSION='1.8.3'
+    export APIGEE_HYBRID_VERSION='1.9.2'
     echo "- Apigee hybrid version $APIGEE_HYBRID_VERSION"
-    export CERT_MANAGER_VERSION='v1.7.3'
+    export CERT_MANAGER_VERSION='v1.11.1'
     echo "- Cert Manager version $CERT_MANAGER_VERSION"
 
     OS_NAME=$(uname -s)
@@ -675,10 +675,9 @@ ingressGateways:
 EOF
 
 if [ "$CERT_TYPE" = "google-managed" ]; then
-  echo "Setting Apigee Ingress IB to Internal because Ingress resource is used"
+  echo "Do not create a LB because the ingress resource is used to create a GCLB with a managed cert"
 cat << EOF >> "$HYBRID_HOME"/overrides/overrides.yaml
-  svcAnnotations:
-    networking.gke.io/load-balancer-type: "Internal"
+  svcType: ClusterIP
 EOF
 else
 cat << EOF >> "$HYBRID_HOME"/overrides/overrides.yaml
@@ -769,6 +768,8 @@ enable_trace() {
 
 deploy_example_proxy() {
   echo "🦄 Deploy Sample Proxy"
+
+  kubectl apply -f "$QUICKSTART_ROOT/example-proxy/resources.yaml"
 
   ENV_NAME=$1
   ENV_GROUP_NAME=$2


### PR DESCRIPTION
## Description
What's changed, or what was fixed?

- bumped Apigee hybrid to 1.9.2
- removed the need for internal LB for the automatically generated ingress gateway
- created an in-cluster httpbin deployment for the sample-proxy to reduce dependencies on external service


## Housekeeping
(please check all that apply [x], do not edit the text)
- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.

## Full Repo Validation Required
(please check all that apply [x], do not edit the text)
- [ ] PR requires full pipeline run (Run for changes only by default).

**CC:** @apigee-devrel-reviewers
