### PR TITLE
docs(apigee-envoy-quickstart): fix copy-paste error on cli instruction

### DIFF
--- a/tools/apigee-envoy-quickstart/README.md
+++ b/tools/apigee-envoy-quickstart/README.md
@@ -136,7 +136,7 @@ The Apigee Envoy Quickstart Toolkit sets up the Envoy proxies with Apigee adapte
 1. **Run to install the quickstart toolkit.**
     ```bash
     cd ${DEVREL_HOME}/tools/apigee-envoy-quickstart/
-    ./aekitctl.sh --type istio-apigee-envoy --action install
+    ./aekitctl.sh --type standalone-apigee-envoy --action install
     ```
 
 1. **On successful run, it displays the commands (kubeclt run, curl) to validate the traffic intiated to the Envoy endpoints being protected by Apigee Adapter service.**


### PR DESCRIPTION
## Description
What's changed, or what was fixed?

- Fix Copy paste error for standalone envoy example

## Housekeeping
(please check all that apply [x], do not edit the text)
- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.

## Full Repo Validation Required
(please check all that apply [x], do not edit the text)
- [ ] PR requires full pipeline run (Run for changes only by default).

**CC:** @apigee-devrel-reviewers
