### PR TITLE
fix(data-api): remove nullable fields from data-api test cases

### DIFF
--- a/references/data-api/test/integration/features/bikerentals.feature
+++ b/references/data-api/test/integration/features/bikerentals.feature
@@ -22,8 +22,6 @@ Feature:
     Then response code should be 200
     And response body path $ should be of type array with length 5
     And response body path $.[0].rental_id should not be null
-    And response body path $.[0].bike_id should not be null
-    And response body path $.[0].duration should not be null
 
   Scenario: Get a specific number of bike rentals
     Given I set query parameters to
@@ -61,5 +59,3 @@ Feature:
     When I GET /bikerentals
     Then response code should be 200
     And response body path $.[0].rental_id should not be null
-    And response body path $.[0].bike_id should not be null
-    And response body path $.[0].duration should be null


### PR DESCRIPTION
## Description
What's changed, or what was fixed?

- Fixes the data-api test failures in the nighty because the bike rental dataset includes null values:

**Query to count entries that would fail the test:**

```sql
SELECT  count(rental_id) FROM `bigquery-public-data.london_bicycles.cycle_hire`  where duration IS NULL OR bike_id IS NULL
```

**Result:**
```txt
19600
```



## Issues Fixed
- Fixes: Nighly 🤞 

## Housekeeping
(please check all that apply [x], do not edit the text)
- [x] I have run all the tests locally and they all pass.
- [x] I have followed the relevant style guide for my changes.

## Full Repo Validation Required
(please check all that apply [x], do not edit the text)
- [ ] PR requires full pipeline run (Run for changes only by default).

**CC:** @apigee-devrel-reviewers
