### PR TITLE
Replace httpbin with mocktarget

### DIFF
--- a/labs/idp-okta-integration/README.md
+++ b/labs/idp-okta-integration/README.md
@@ -180,7 +180,7 @@ This test will simulate a three-legged [OAuth 2.0](https://cloud.google.com/apig
      - You can generate the authorization url using the command below.
 
      ```bash
-     export AUTH_URL="https://$APIGEE_X_HOSTNAME/v1/oauth20/authorize?client_id=$APIGEE_CLIENT_ID&response_type=code&scope=openid email profile&state=abcd-1234&redirect_uri=https://httpbin.org/get"
+     export AUTH_URL="https://$APIGEE_X_HOSTNAME/v1/oauth20/authorize?client_id=$APIGEE_CLIENT_ID&response_type=code&scope=openid email profile&state=abcd-1234&redirect_uri=https://mocktarget.apigee.net/echo"
      echo $AUTH_URL
      ```
 
@@ -188,7 +188,7 @@ This test will simulate a three-legged [OAuth 2.0](https://cloud.google.com/apig
 
      ![Okta Auth](assets/okta-auth-code-login.png)
 
-3. After successful authentication, Okta redirects to the Apigee callback URL (/v1/oauth20/callback), which controls the incoming query parameters, generate an authorization code (using the same value as the one provided by Okta) and performs a redirection on the client app redirect_uri `https://httpbin.org/get` providing the authorization_code and initial state parameters.
+3. After successful authentication, Okta redirects to the Apigee callback URL (/v1/oauth20/callback), which controls the incoming query parameters, generate an authorization code (using the same value as the one provided by Okta) and performs a redirection on the client app redirect_uri `https://mocktarget.apigee.net/echo` providing the authorization_code and initial state parameters.
 
      - In a real-world scenario, the redirection would be back to the client application and it would parse Okta's response to capture the authorization code
 
@@ -201,7 +201,7 @@ This test will simulate a three-legged [OAuth 2.0](https://cloud.google.com/apig
      export APIGEE_RESPONSE=$(curl -s --location --request POST "https://$APIGEE_X_HOSTNAME/v1/oauth20/token?client_id=$APIGEE_CLIENT_ID" \
      --header "Authorization: Basic $BASE64_ENCODED" \
      --header 'Content-Type: application/x-www-form-urlencoded' \
-     --data-urlencode 'redirect_uri=https://httpbin.org/get' \
+     --data-urlencode 'redirect_uri=https://mocktarget.apigee.net/echo' \
      --data-urlencode 'grant_type=authorization_code' \
      --data-urlencode "code=$AUTH_CODE")
      echo $APIGEE_RESPONSE
@@ -266,7 +266,7 @@ The default Apigee install includes a /hello-world proxy. In this section we wil
      export APIGEE_CLIENT_ID=F3gGHZGtPPg6FcZqo0JwXFbV2NVkW0ILOXKte9HMFWJsOgR8
      export APIGEE_SECRET=3m5VFXhQIcMO45dhK8YZ85Svw97iTIdiuBnIQMSPJQrZHQQrkQ1aPsYJ3gWVec41
      export BASE64_ENCODED=$(echo -n $APIGEE_CLIENT_ID:$APIGEE_SECRET | base64)
-     export AUTH_URL="https://$APIGEE_X_HOSTNAME/v1/oauth20/authorize?client_id=$APIGEE_CLIENT_ID&response_type=code&scope=openid email profile&state=abcd-1234&redirect_uri=https://httpbin.org/get"
+     export AUTH_URL="https://$APIGEE_X_HOSTNAME/v1/oauth20/authorize?client_id=$APIGEE_CLIENT_ID&response_type=code&scope=openid email profile&state=abcd-1234&redirect_uri=https://mocktarget.apigee.net/echo"
      echo "$AUTH_URL"
      ```
 
@@ -285,7 +285,7 @@ The default Apigee install includes a /hello-world proxy. In this section we wil
      export AUTH_CODE={authorization code returned above}
      export APIGEE_RESPONSE=$(curl -s --location --request POST "https://$APIGEE_X_HOSTNAME/v1/oauth20/token?client_id=$APIGEE_CLIENT_ID" \--header "Authorization: Basic $BASE64_ENCODED" \
      --header 'Content-Type: application/x-www-form-urlencoded' \
-     --data-urlencode 'redirect_uri=https://httpbin.org/get' \
+     --data-urlencode 'redirect_uri=https://mocktarget.apigee.net/echo' \
      --data-urlencode 'grant_type=authorization_code' \
      --data-urlencode "code=$AUTH_CODE")
 

--- a/references/cicd-sharedflow-pipeline/test/integration/apiproxy/targets/default.xml
+++ b/references/cicd-sharedflow-pipeline/test/integration/apiproxy/targets/default.xml
@@ -28,6 +28,6 @@
     <Flows/>
     <HTTPTargetConnection>
         <Properties/>
-        <URL>http://httpbin.org/get</URL>
+        <URL>https://mocktarget.apigee.net/echo</URL>
     </HTTPTargetConnection>
 </TargetEndpoint>

--- a/references/dutch-healthcare/healthcare-v1/apiproxy/resources/jsc/EnrichAllergyResponse.js
+++ b/references/dutch-healthcare/healthcare-v1/apiproxy/resources/jsc/EnrichAllergyResponse.js
@@ -20,13 +20,12 @@ function onComplete(response,error) {
 
       // update response payload with new patient name
       var payload = JSON.parse(context.getVariable("response.content"));
-      payload.patient.display = response.content.substring(7, response.content.length-1)
+      payload.patient.display = response.content.asJSON.args.name;
       context.setVariable("response.content", JSON.stringify(payload))
-
      } else {
        throw error;
      }
 }
 
 // Make an additional request
-httpClient.get("https://mocktarget.apigee.net/user?user=Mediated Display Name", onComplete);
+httpClient.get("https://mocktarget.apigee.net/echo?name=Mediated Display Name", onComplete);

--- a/references/dutch-healthcare/healthcare-v1/apiproxy/resources/jsc/EnrichAllergyResponse.js
+++ b/references/dutch-healthcare/healthcare-v1/apiproxy/resources/jsc/EnrichAllergyResponse.js
@@ -29,4 +29,4 @@ function onComplete(response,error) {
 }
 
 // Make an additional request
-httpClient.get("https://httpbin.org/get?name=Mediated Display Name", onComplete);
+httpClient.get("https://mocktarget.apigee.net/echo?name=Mediated Display Name", onComplete);

--- a/references/dutch-healthcare/healthcare-v1/apiproxy/resources/jsc/EnrichAllergyResponse.js
+++ b/references/dutch-healthcare/healthcare-v1/apiproxy/resources/jsc/EnrichAllergyResponse.js
@@ -20,7 +20,7 @@ function onComplete(response,error) {
 
       // update response payload with new patient name
       var payload = JSON.parse(context.getVariable("response.content"));
-      payload.patient.display = response.content.asJSON.args.name;
+      payload.patient.display = response.content.substring(7, response.content.length-1)
       context.setVariable("response.content", JSON.stringify(payload))
 
      } else {
@@ -29,4 +29,4 @@ function onComplete(response,error) {
 }
 
 // Make an additional request
-httpClient.get("https://mocktarget.apigee.net/echo?name=Mediated Display Name", onComplete);
+httpClient.get("https://mocktarget.apigee.net/user?user=Mediated Display Name", onComplete);

--- a/references/identity-facade/pipeline.sh
+++ b/references/identity-facade/pipeline.sh
@@ -206,7 +206,7 @@ generate_edge_json() {
                     "apiProducts": [
                         "IdentityFacade"
                     ],
-                    "callbackUrl": "https://httpbin.org/get",
+                    "callbackUrl": "https://mocktarget.apigee.net/echo",
                     "scopes": []
                 }
             ]
@@ -259,7 +259,7 @@ generate_authz_url() {
     RESPONSE_TYPE="&response_type=code"
     SCOPE="&scope=openid email profile"
     STATE="&state=abcd-1234"
-    REDIRECT_URI="&redirect_uri=https://httpbin.org/get"
+    REDIRECT_URI="&redirect_uri=https://mocktarget.apigee.net/echo"
 
     # is pkce enabled (=true) or not
     if [ "$4" = "true" ];then

--- a/references/identity-facade/test/integration/features/identity-facade.authorize-pkce.feature
+++ b/references/identity-facade/test/integration/features/identity-facade.authorize-pkce.feature
@@ -1,24 +1,24 @@
 @pkce @authorize
 Feature:
-  As a Client App 
+  As a Client App
   I want to access the protected resource of an API
   So that I can retrieve different types of information
 
   Scenario: I should get an error if client_id is missing or invalid
-    When I GET /authorize?client_id=xxx&redirect_uri=https://httpbin.org/get&response_type=code&state=12345&scope=openid%20email`pkceCodeVerifier`
+    When I GET /authorize?client_id=xxx&redirect_uri=https://mocktarget.apigee.net/echo&response_type=code&state=12345&scope=openid%20email`pkceCodeVerifier`
     Then response code should be 401
     And response body should be valid json
 
   Scenario: I should get an error if client_id contains heading or trailing spaces
-    When I GET /authorize?client_id=`spaceCharacters``clientId`&redirect_uri=https://httpbin.org/get&response_type=code&state=12345&scope=openid%20email`pkceCodeVerifier`
+    When I GET /authorize?client_id=`spaceCharacters``clientId`&redirect_uri=https://mocktarget.apigee.net/echo&response_type=code&state=12345&scope=openid%20email`pkceCodeVerifier`
     Then response code should be 401
     And response body should be valid json
-    
+
   Scenario: I should get an error if redirect_uri is missing or invalid
     When I GET /authorize?client_id=`clientId`&redirect_uri=https://example.com/invalid&response_type=code&state=12345&scope=openid%20email`pkceCodeVerifier`
     Then response code should be 400
     And response body path $.error should be invalid_request
-    
+
   Scenario: I should get an error if response_type is missing or invalid
     Given I navigate to the authorize page with an invalid response type
     Then I am redirected to the Client App
@@ -28,7 +28,7 @@ Feature:
     Given I navigate to the authorize page without a scope parameter
     Then I am redirected to the Client App
     Then I receive an invalid_request error
-    
+
   Scenario: User Authorizes with state missing
     Given I navigate to the authorize page without a state parameter
     When I sign in and consent

--- a/references/identity-facade/test/integration/features/identity-facade.authorize.feature
+++ b/references/identity-facade/test/integration/features/identity-facade.authorize.feature
@@ -1,24 +1,24 @@
 @authorize
 Feature:
-  As a Client App 
+  As a Client App
   I want to access the protected resource of an API
   So that I can retrieve different types of information
 
   Scenario: I should get an error if client_id is missing or invalid
-    When I GET /authorize?client_id=xxx&redirect_uri=https://httpbin.org/get&response_type=code&state=12345&scope=openid%20email
+    When I GET /authorize?client_id=xxx&redirect_uri=https://mocktarget.apigee.net/echo&response_type=code&state=12345&scope=openid%20email
     Then response code should be 401
     And response body should be valid json
 
   Scenario: I should get an error if client_id contains heading or trailing spaces
-    When I GET /authorize?client_id=`spaceCharacters``clientId`&redirect_uri=https://httpbin.org/get&response_type=code&state=12345&scope=openid%20email
+    When I GET /authorize?client_id=`spaceCharacters``clientId`&redirect_uri=https://mocktarget.apigee.net/echo&response_type=code&state=12345&scope=openid%20email
     Then response code should be 401
     And response body should be valid json
-    
+
   Scenario: I should get an error if redirect_uri is missing or invalid
     When I GET /authorize?client_id=`clientId`&redirect_uri=https://example.com/invalid&response_type=code&state=12345&scope=openid%20email
     Then response code should be 400
     And response body path $.error should be invalid_request
-    
+
   Scenario: I should get an error if response_type is missing or invalid
     Given I navigate to the authorize page with an invalid response type
     Then I am redirected to the Client App
@@ -28,14 +28,14 @@ Feature:
     Given I navigate to the authorize page without a scope parameter
     Then I am redirected to the Client App
     Then I receive an invalid_request error
-    
+
   Scenario: User Authorizes with state missing
     Given I navigate to the authorize page without a state parameter
     When I sign in and consent
     Then I am redirected to the Client App
     And I receive an auth code in a query param
     And I store the auth code in global scope
-  
+
   Scenario: User Authorizes
     Given I navigate to the authorize page
     When I sign in and consent

--- a/references/identity-facade/test/integration/features/identity-facade.end2end-pkce.feature
+++ b/references/identity-facade/test/integration/features/identity-facade.end2end-pkce.feature
@@ -1,6 +1,6 @@
 @pkce @end2end
 Feature:
-  As a Client App 
+  As a Client App
   I want to access the protected resource of an API
   So that I can retrieve different types of information
 
@@ -14,11 +14,11 @@ Feature:
 
   Scenario: Generate Access Token
     Given I have basic authentication credentials `clientId` and `clientSecret`
-    And I set form parameters to 
+    And I set form parameters to
       | parameter   | value		      |
       | grant_type  | authorization_code      |
       | code        | `authCode`              |
-      | redirect_uri| https://httpbin.org/get |
+      | redirect_uri| https://mocktarget.apigee.net/echo |
       |	state	    | `state`		      |
       |	scope	    | `scope`		      |
       | code_verifier | `codeVerifier` |

--- a/references/identity-facade/test/integration/features/identity-facade.end2end.feature
+++ b/references/identity-facade/test/integration/features/identity-facade.end2end.feature
@@ -1,6 +1,6 @@
 @end2end
 Feature:
-  As a Client App 
+  As a Client App
   I want to access the protected resource of an API
   So that I can retrieve different types of information
 
@@ -14,11 +14,11 @@ Feature:
 
   Scenario: Generate Access Token
     Given I have basic authentication credentials `clientId` and `clientSecret`
-    And I set form parameters to 
+    And I set form parameters to
       | parameter   | value		      |
       | grant_type  | authorization_code      |
       | code        | `authCode`              |
-      | redirect_uri| https://httpbin.org/get |
+      | redirect_uri| https://mocktarget.apigee.net/echo |
       |	state	    | `state`		      |
       |	scope	    | `scope`		      |
     When I POST to /token

--- a/references/identity-facade/test/integration/features/identity-facade.token-basic-auth.feature
+++ b/references/identity-facade/test/integration/features/identity-facade.token-basic-auth.feature
@@ -1,6 +1,6 @@
 @token
 Feature:
-  As a Client App 
+  As a Client App
   I want to access the protected resource of an API
   So that I can retrieve different types of information
 
@@ -14,40 +14,40 @@ Feature:
 
   Scenario: Generate Access Token
     Given I have basic authentication credentials `clientId` and `clientSecret`
-    And I set form parameters to 
+    And I set form parameters to
       | parameter   | value		      |
       | grant_type  | authorization_code      |
       | code        | `authCode`              |
-      | redirect_uri| https://httpbin.org/get |
+      | redirect_uri| https://mocktarget.apigee.net/echo |
     When I POST to /token
     Then response code should be 200
     And I store the value of body path $.access_token as userToken in global scope
 
   Scenario: I should get an error if client_id is invalid
     Given I have basic authentication credentials invalid-client_id and `clientSecret`
-    And I set form parameters to 
+    And I set form parameters to
       | parameter   | value		      |
       | grant_type  | authorization_code      |
       | code        | `authCode`              |
-      | redirect_uri| https://httpbin.org/get |
+      | redirect_uri| https://mocktarget.apigee.net/echo |
     When I POST to /token
     Then response code should be 401
     And response body should be valid json
 
   Scenario: I should get an error if client_secret is invalid
     Given I have basic authentication credentials `clientId` and invalid-client_secret
-    And I set form parameters to 
+    And I set form parameters to
       | parameter   | value		      |
       | grant_type  | authorization_code      |
       | code        | `authCode`              |
-      | redirect_uri| https://httpbin.org/get |
+      | redirect_uri| https://mocktarget.apigee.net/echo |
     When I POST to /token
     Then response code should be 401
     And response body path $.error should be invalid_client
 
   Scenario: I should get an error if redirect_uri is missing or invalid
     Given I have basic authentication credentials `clientId` and `clientSecret`
-    And I set form parameters to 
+    And I set form parameters to
       | parameter   | value		      |
       | grant_type  | authorization_code      |
       | code        | `authCode`              |
@@ -55,35 +55,35 @@ Feature:
     When I POST to /token
     Then response code should be 400
     And response body path $.error should be invalid_request
-  
+
   Scenario: I should get an error if authorization code is invalid
     Given I have basic authentication credentials `clientId` and `clientSecret`
-    And I set form parameters to 
+    And I set form parameters to
       | parameter   | value		      |
       | grant_type  | authorization_code      |
       | code        | invalid-code            |
-      | redirect_uri| https://httpbin.org/get |
+      | redirect_uri| https://mocktarget.apigee.net/echo |
     When I POST to /token
     Then response code should be 404
     And response body should be valid json
 
   Scenario: I should get an error if authorization code is missing
     Given I have basic authentication credentials `clientId` and `clientSecret`
-    And I set form parameters to 
+    And I set form parameters to
       | parameter   | value		      |
       | grant_type  | authorization_code      |
-      | redirect_uri| https://httpbin.org/get |
+      | redirect_uri| https://mocktarget.apigee.net/echo |
     When I POST to /token
     Then response code should be 400
     And response body path $.error should be invalid_grant
 
   Scenario: I should get an error if grant_type is not authorization_code
     Given I have basic authentication credentials `clientId` and `clientSecret`
-    And I set form parameters to 
+    And I set form parameters to
       | parameter   | value		      |
       | grant_type  | xxx           |
       | code        | `authCode`              |
-      | redirect_uri| https://httpbin.org/get |
+      | redirect_uri| https://mocktarget.apigee.net/echo |
     When I POST to /token
     Then response code should be 400
     And response body path $.error should be unsupported_grant_type

--- a/references/identity-facade/test/integration/features/identity-facade.token-forms-auth.feature
+++ b/references/identity-facade/test/integration/features/identity-facade.token-forms-auth.feature
@@ -1,6 +1,6 @@
 @token
 Feature:
-  As a Client App 
+  As a Client App
   I want to access the protected resource of an API
   So that I can retrieve different types of information
 
@@ -13,11 +13,11 @@ Feature:
     And I store the state parameter in global scope
 
   Scenario: Generate Access Token
-    Given I set form parameters to 
+    Given I set form parameters to
       | parameter   | value		      |
       | grant_type  | authorization_code      |
       | code        | `authCode`              |
-      | redirect_uri| https://httpbin.org/get |
+      | redirect_uri| https://mocktarget.apigee.net/echo |
       | client_id     | `clientId`              |
       | client_secret | `clientSecret`          |
     When I POST to /token
@@ -25,11 +25,11 @@ Feature:
     And I store the value of body path $.access_token as userToken in global scope
 
   Scenario: I should get an error if client_id is invalid
-    Given I set form parameters to 
+    Given I set form parameters to
       | parameter   | value		      |
       | grant_type  | authorization_code      |
       | code        | `authCode`              |
-      | redirect_uri| https://httpbin.org/get |
+      | redirect_uri| https://mocktarget.apigee.net/echo |
       | client_id     | invalid-client          |
       | client_secret | `clientSecret`          |
     When I POST to /token
@@ -37,11 +37,11 @@ Feature:
     And response body should be valid json
 
   Scenario: I should get an error if client_secret is invalid
-    Given I set form parameters to 
+    Given I set form parameters to
       | parameter   | value		      |
       | grant_type  | authorization_code      |
       | code        | `authCode`              |
-      | redirect_uri| https://httpbin.org/get |
+      | redirect_uri| https://mocktarget.apigee.net/echo |
       | client_id     | `clientId`              |
       | client_secret | invalid-client          |
     When I POST to /token
@@ -49,7 +49,7 @@ Feature:
     And response body path $.error should be invalid_client
 
   Scenario: I should get an error if redirect_uri is missing or invalid
-    Given I set form parameters to 
+    Given I set form parameters to
       | parameter   | value		      |
       | grant_type  | authorization_code      |
       | code        | `authCode`              |
@@ -59,13 +59,13 @@ Feature:
     When I POST to /token
     Then response code should be 400
     And response body path $.error should be invalid_request
-  
+
   Scenario: I should get an error if authorization code is invalid
-    Given I set form parameters to 
+    Given I set form parameters to
       | parameter   | value		      |
       | grant_type  | authorization_code      |
       | code        | invalid-code            |
-      | redirect_uri| https://httpbin.org/get |
+      | redirect_uri| https://mocktarget.apigee.net/echo |
       | client_id     | `clientId`              |
       | client_secret | `clientSecret`          |
     When I POST to /token
@@ -73,10 +73,10 @@ Feature:
     And response body should be valid json
 
   Scenario: I should get an error if authorization code is missing
-    Given I set form parameters to 
+    Given I set form parameters to
       | parameter   | value		      |
       | grant_type  | authorization_code      |
-      | redirect_uri| https://httpbin.org/get |
+      | redirect_uri| https://mocktarget.apigee.net/echo |
       | client_id     | `clientId`              |
       | client_secret | `clientSecret`          |
     When I POST to /token
@@ -84,11 +84,11 @@ Feature:
     And response body path $.error should be invalid_grant
 
   Scenario: I should get an error if grant_type is not authorization_code
-    Given I set form parameters to 
+    Given I set form parameters to
       | parameter   | value		      |
       | grant_type  | xxx           |
       | code        | `authCode`              |
-      | redirect_uri| https://httpbin.org/get |
+      | redirect_uri| https://mocktarget.apigee.net/echo |
       | client_id     | `clientId`              |
       | client_secret | `clientSecret`          |
     When I POST to /token

--- a/references/identity-facade/test/integration/features/identity-facade.token-pkce-basic-auth.feature
+++ b/references/identity-facade/test/integration/features/identity-facade.token-pkce-basic-auth.feature
@@ -1,6 +1,6 @@
 @pkce @token
 Feature:
-  As a Client App 
+  As a Client App
   I want to access the protected resource of an API
   So that I can retrieve different types of information
 
@@ -14,11 +14,11 @@ Feature:
 
   Scenario: Generate Access Token
     Given I have basic authentication credentials `clientId` and `clientSecret`
-    And I set form parameters to 
+    And I set form parameters to
       | parameter   | value		      |
       | grant_type  | authorization_code      |
       | code        | `authCode`              |
-      | redirect_uri| https://httpbin.org/get |
+      | redirect_uri| https://mocktarget.apigee.net/echo |
       | code_verifier | `codeVerifier` |
     When I POST to /token
     Then response code should be 200
@@ -26,11 +26,11 @@ Feature:
 
   Scenario: I should get an error if client_id is invalid
     Given I have basic authentication credentials invalid-client_id and `clientSecret`
-    And I set form parameters to 
+    And I set form parameters to
       | parameter   | value		      |
       | grant_type  | authorization_code      |
       | code        | `authCode`              |
-      | redirect_uri| https://httpbin.org/get |
+      | redirect_uri| https://mocktarget.apigee.net/echo |
       | code_verifier | `codeVerifier` |
     When I POST to /token
     Then response code should be 401
@@ -38,11 +38,11 @@ Feature:
 
   Scenario: I should get an error if client_secret is invalid
     Given I have basic authentication credentials `clientId` and invalid-client_secret
-    And I set form parameters to 
+    And I set form parameters to
       | parameter   | value		      |
       | grant_type  | authorization_code      |
       | code        | `authCode`              |
-      | redirect_uri| https://httpbin.org/get |
+      | redirect_uri| https://mocktarget.apigee.net/echo |
       | code_verifier | `codeVerifier` |
     When I POST to /token
     Then response code should be 401
@@ -50,7 +50,7 @@ Feature:
 
   Scenario: I should get an error if redirect_uri is missing or invalid
     Given I have basic authentication credentials `clientId` and `clientSecret`
-    And I set form parameters to 
+    And I set form parameters to
       | parameter   | value		      |
       | grant_type  | authorization_code      |
       | code        | `authCode`              |
@@ -59,14 +59,14 @@ Feature:
     When I POST to /token
     Then response code should be 400
     And response body path $.error should be invalid_request
-  
+
   Scenario: I should get an error if authorization code is invalid
     Given I have basic authentication credentials `clientId` and `clientSecret`
-    And I set form parameters to 
+    And I set form parameters to
       | parameter   | value		      |
       | grant_type  | authorization_code      |
       | code        | invalid-code            |
-      | redirect_uri| https://httpbin.org/get |
+      | redirect_uri| https://mocktarget.apigee.net/echo |
       | code_verifier | `codeVerifier` |
     When I POST to /token
     Then response code should be 404
@@ -74,10 +74,10 @@ Feature:
 
   Scenario: I should get an error if authorization code is missing
     Given I have basic authentication credentials `clientId` and `clientSecret`
-    And I set form parameters to 
+    And I set form parameters to
       | parameter   | value		      |
       | grant_type  | authorization_code      |
-      | redirect_uri| https://httpbin.org/get |
+      | redirect_uri| https://mocktarget.apigee.net/echo |
       | code_verifier | `codeVerifier` |
     When I POST to /token
     Then response code should be 400
@@ -85,11 +85,11 @@ Feature:
 
   Scenario: I should get an error if grant_type is not authorization_code
     Given I have basic authentication credentials `clientId` and `clientSecret`
-    And I set form parameters to 
+    And I set form parameters to
       | parameter   | value		      |
       | grant_type  | xxx           |
       | code        | `authCode`              |
-      | redirect_uri| https://httpbin.org/get |
+      | redirect_uri| https://mocktarget.apigee.net/echo |
       | code_verifier | `codeVerifier` |
     When I POST to /token
     Then response code should be 400
@@ -105,11 +105,11 @@ Feature:
 
   Scenario: I should get an error if code_verifier is wrong or missing
     Given I have basic authentication credentials `clientId` and `clientSecret`
-    And I set form parameters to 
+    And I set form parameters to
       | parameter   | value		      |
       | grant_type  | authorization_code      |
       | code        | `authCode`              |
-      | redirect_uri| https://httpbin.org/get |
+      | redirect_uri| https://mocktarget.apigee.net/echo |
       | code_verifier| xxx |
     When I POST to /token
     Then response code should be 400

--- a/references/identity-facade/test/integration/features/identity-facade.token-pkce-forms-auth.feature
+++ b/references/identity-facade/test/integration/features/identity-facade.token-pkce-forms-auth.feature
@@ -1,6 +1,6 @@
 @pkce @token
 Feature:
-  As a Client App 
+  As a Client App
   I want to access the protected resource of an API
   So that I can retrieve different types of information
 
@@ -13,11 +13,11 @@ Feature:
     And I store the state parameter in global scope
 
   Scenario: Generate Access Token
-    Given I set form parameters to 
+    Given I set form parameters to
       | parameter   | value		      |
       | grant_type  | authorization_code      |
       | code        | `authCode`              |
-      | redirect_uri| https://httpbin.org/get |
+      | redirect_uri| https://mocktarget.apigee.net/echo |
       | code_verifier | `codeVerifier` |
       | client_id     | `clientId`              |
       | client_secret | `clientSecret`          |
@@ -26,11 +26,11 @@ Feature:
     And I store the value of body path $.access_token as userToken in global scope
 
   Scenario: I should get an error if client_id is invalid
-    Given I set form parameters to 
+    Given I set form parameters to
       | parameter   | value		      |
       | grant_type  | authorization_code      |
       | code        | `authCode`              |
-      | redirect_uri| https://httpbin.org/get |
+      | redirect_uri| https://mocktarget.apigee.net/echo |
       | code_verifier | `codeVerifier` |
       | client_id     | invalid-client          |
       | client_secret | `clientSecret`          |
@@ -39,11 +39,11 @@ Feature:
     And response body should be valid json
 
   Scenario: I should get an error if client_secret is invalid
-    Given I set form parameters to 
+    Given I set form parameters to
       | parameter   | value		      |
       | grant_type  | authorization_code      |
       | code        | `authCode`              |
-      | redirect_uri| https://httpbin.org/get |
+      | redirect_uri| https://mocktarget.apigee.net/echo |
       | code_verifier | `codeVerifier` |
       | client_id     | `clientId`              |
       | client_secret | invalid-client          |
@@ -52,7 +52,7 @@ Feature:
     And response body path $.error should be invalid_client
 
   Scenario: I should get an error if redirect_uri is missing or invalid
-    Given I set form parameters to 
+    Given I set form parameters to
       | parameter   | value		      |
       | grant_type  | authorization_code      |
       | code        | `authCode`              |
@@ -63,13 +63,13 @@ Feature:
     When I POST to /token
     Then response code should be 400
     And response body path $.error should be invalid_request
-  
+
   Scenario: I should get an error if authorization code is invalid
-    Given I set form parameters to 
+    Given I set form parameters to
       | parameter   | value		      |
       | grant_type  | authorization_code      |
       | code        | invalid-code            |
-      | redirect_uri| https://httpbin.org/get |
+      | redirect_uri| https://mocktarget.apigee.net/echo |
       | code_verifier | `codeVerifier` |
       | client_id     | `clientId`              |
       | client_secret | `clientSecret`          |
@@ -78,10 +78,10 @@ Feature:
     And response body should be valid json
 
   Scenario: I should get an error if authorization code is missing
-    Given I set form parameters to 
+    Given I set form parameters to
       | parameter   | value		      |
       | grant_type  | authorization_code      |
-      | redirect_uri| https://httpbin.org/get |
+      | redirect_uri| https://mocktarget.apigee.net/echo |
       | code_verifier | `codeVerifier` |
       | client_id     | `clientId`              |
       | client_secret | `clientSecret`          |
@@ -90,11 +90,11 @@ Feature:
     And response body path $.error should be invalid_grant
 
   Scenario: I should get an error if grant_type is not authorization_code
-    Given I set form parameters to 
+    Given I set form parameters to
       | parameter   | value		      |
       | grant_type  | xxx           |
       | code        | `authCode`              |
-      | redirect_uri| https://httpbin.org/get |
+      | redirect_uri| https://mocktarget.apigee.net/echo |
       | code_verifier | `codeVerifier` |
       | client_id     | `clientId`              |
       | client_secret | `clientSecret`          |
@@ -111,11 +111,11 @@ Feature:
     And I store the state parameter in global scope
 
   Scenario: I should get an error if code_verifier is wrong or missing
-    Given I set form parameters to 
+    Given I set form parameters to
       | parameter   | value		      |
       | grant_type  | authorization_code      |
       | code        | `authCode`              |
-      | redirect_uri| https://httpbin.org/get |
+      | redirect_uri| https://mocktarget.apigee.net/echo |
       | code_verifier| xxx |
       | client_id     | `clientId`              |
       | client_secret | `clientSecret`          |

--- a/references/identity-facade/test/integration/features/step_definitions/ui.js
+++ b/references/identity-facade/test/integration/features/step_definitions/ui.js
@@ -40,7 +40,7 @@ Given('I navigate to the authorize page', async function() {
   })
   this.page = await this.browser.newPage()
   return await this.page.goto('https://' + hostname + basePath + '/authorize?client_id=' + this.apickli.scenarioVariables.clientId
-    + '&redirect_uri=https://httpbin.org/get&response_type=code&state=' + state +'&scope=' + scope
+    + '&redirect_uri=https://mocktarget.apigee.net/echo&response_type=code&state=' + state +'&scope=' + scope
     + pkceQueryParams)
 })
 
@@ -53,7 +53,7 @@ Given('I navigate to the authorize page with query params that must be sanitized
   })
   this.page = await this.browser.newPage()
   return await this.page.goto('https://' + hostname + basePath + '/authorize?client_id=' + '    ' + this.apickli.scenarioVariables.clientId
-    + '&redirect_uri= https://httpbin.org/get&response_type=code&state=' + state +'&scope=' + scope
+    + '&redirect_uri= https://mocktarget.apigee.net/echo&response_type=code&state=' + state +'&scope=' + scope
     + pkceQueryParams)
 })
 
@@ -66,7 +66,7 @@ Given('I navigate to the authorize page with an invalid response type', async fu
   })
   this.page = await this.browser.newPage()
   return await this.page.goto('https://' + hostname + basePath + '/authorize?client_id=' + this.apickli.scenarioVariables.clientId
-    + '&redirect_uri=https://httpbin.org/get&response_type=xxx&state=' + state +'&scope=' + scope
+    + '&redirect_uri=https://mocktarget.apigee.net/echo&response_type=xxx&state=' + state +'&scope=' + scope
     + pkceQueryParams)
 })
 
@@ -79,7 +79,7 @@ Given('I navigate to the authorize page without a scope parameter', async functi
   })
   this.page = await this.browser.newPage()
   return await this.page.goto('https://' + hostname + basePath + '/authorize?client_id=' + this.apickli.scenarioVariables.clientId
-    + '&redirect_uri=https://httpbin.org/get&response_type=code&state=' + state
+    + '&redirect_uri=https://mocktarget.apigee.net/echo&response_type=code&state=' + state
     + pkceQueryParams)
 })
 
@@ -92,7 +92,7 @@ Given('I navigate to the authorize page without a state parameter', async functi
   })
   this.page = await this.browser.newPage()
   return await this.page.goto('https://' + hostname + basePath + '/authorize?client_id=' + this.apickli.scenarioVariables.clientId
-    + '&redirect_uri=https://httpbin.org/get&response_type=code&scope=' + scope
+    + '&redirect_uri=https://mocktarget.apigee.net/echo&response_type=code&scope=' + scope
     + pkceQueryParams)
 })
 
@@ -106,7 +106,7 @@ if (isPkceEnabled) {
     })
     this.page = await this.browser.newPage()
     return await this.page.goto('https://' + hostname + basePath + '/authorize?client_id=' + this.apickli.scenarioVariables.clientId
-      + '&redirect_uri=https://httpbin.org/get&response_type=code&state=' + state +'&scope=' + scope
+      + '&redirect_uri=https://mocktarget.apigee.net/echo&response_type=code&state=' + state +'&scope=' + scope
       + '&code_challenge=' + this.apickli.scenarioVariables.codeChallenge + '&code_challenge_method=xxx')
   })
 
@@ -118,7 +118,7 @@ if (isPkceEnabled) {
     })
     this.page = await this.browser.newPage()
     return await this.page.goto('https://' + hostname + basePath + '/authorize?client_id=' + this.apickli.scenarioVariables.clientId
-      + '&redirect_uri=https://httpbin.org/get&response_type=code&state=' + state +'&scope=' + scope
+      + '&redirect_uri=https://mocktarget.apigee.net/echo&response_type=code&state=' + state +'&scope=' + scope
       + '&code_challenge=' + this.apickli.scenarioVariables.codeChallenge)
   })
 
@@ -130,7 +130,7 @@ if (isPkceEnabled) {
     })
     this.page = await this.browser.newPage()
     return await this.page.goto('https://' + hostname + basePath + '/authorize?client_id=' + this.apickli.scenarioVariables.clientId
-      + '&redirect_uri=https://httpbin.org/get&response_type=code&state=' + state +'&scope=' + scope
+      + '&redirect_uri=https://mocktarget.apigee.net/echo&response_type=code&state=' + state +'&scope=' + scope
       + '&code_challenge_method=S256')
   })
 }
@@ -157,7 +157,7 @@ When('I sign in and consent', async function() {
 })
 
 Then('I am redirected to the Client App', function() {
-  assert.notStrictEqual(this.page.url().indexOf('https://httpbin.org/get'), -1);
+  assert.notStrictEqual(this.page.url().indexOf('https://mocktarget.apigee.net/echo'), -1);
 })
 
 Then('I receive an auth code in a query param', function() {

--- a/references/java-callout/proxy-v1/apiproxy/targets/default.xml
+++ b/references/java-callout/proxy-v1/apiproxy/targets/default.xml
@@ -17,6 +17,6 @@
 
 <TargetEndpoint name="default">
 	<HTTPTargetConnection>
-		<URL>https://httpbin.org/</URL>
+		<URL>https://mocktarget.apigee.net/echo</URL>
 	</HTTPTargetConnection>
 </TargetEndpoint>

--- a/references/java-callout/proxy-v1/test/features/Test.feature
+++ b/references/java-callout/proxy-v1/test/features/Test.feature
@@ -6,4 +6,4 @@ Feature:
   Scenario: Successful Request
     When I GET /get
     Then response code should be 200
-    And response body path $.headers.X-Debug should be true
+    And response body path $.headers.x-debug should be true

--- a/references/js-callout/apiproxy/targets/default.xml
+++ b/references/js-callout/apiproxy/targets/default.xml
@@ -17,6 +17,6 @@
 
 <TargetEndpoint name="default">
   <HTTPTargetConnection>
-    <URL>https://httpbin.org/</URL>
+    <URL>https://mocktarget.apigee.net/echo/</URL>
   </HTTPTargetConnection>
 </TargetEndpoint>

--- a/references/oidc-mock/README.md
+++ b/references/oidc-mock/README.md
@@ -55,7 +55,7 @@ of the OIDC Mock IdP:
 The name of the client app is set to **dummy-client_app**
 The value of the callback url is not checked by the mock OIDC IdP,
 so you can choose the value, which is the most convenient for you
-like: [https://httpbin.org/get](https://httpbin.org/get)
+like: [https://mocktarget.apigee.net/echo](https://mocktarget.apigee.net/echo)
 
 **There is one exception**: should you need working with an invalid
 ```redirect_uri``` value, you can use the only value considered
@@ -175,7 +175,7 @@ Example:
     Method:
     GET
     URI:
-    /v1/openid-connect/authorize?client_id=dummy-client_id-xxx&state=12345&scope=openid%20email&response_type=code&redirect_uri=https://httpbin.org/get
+    /v1/openid-connect/authorize?client_id=dummy-client_id-xxx&state=12345&scope=openid%20email&response_type=code&redirect_uri=https://mocktarget.apigee.net/echo
 
 Output:
 
@@ -240,7 +240,7 @@ Example:
     scope: openid email
     code: dummy-authcode-1606499443624
     state: 12345
-    redirect_uri: https://httpbin.org/get
+    redirect_uri: https://mocktarget.apigee.net/echo
     grant_type: authorization_code
 
 Output:

--- a/references/oidc-mock/test/integration/features/oidc-mock.authorize.feature
+++ b/references/oidc-mock/test/integration/features/oidc-mock.authorize.feature
@@ -1,6 +1,6 @@
 @InitiateAuthentication
 Feature:
-    As a Client App 
+    As a Client App
     I want to get an authorization code from an identity provider
     So that I can retrieve an access_token and id_token
 
@@ -13,13 +13,13 @@ Feature:
         And I store the state parameter in global scope
 
     Scenario: I should get an error if client_id is not provided
-        When I GET /authorize?redirect_uri=https://httpbin.org/get&response_type=code&state=12345&scope=openid%20email
+        When I GET /authorize?redirect_uri=https://mocktarget.apigee.net/echo&response_type=code&state=12345&scope=openid%20email
         Then response code should be 400
-    
+
     Scenario: I should get an error if client_id is wrong
-        When I GET /authorize?client_id=xxx&redirect_uri=https://httpbin.org/get&response_type=code&state=12345&scope=openid%20email
+        When I GET /authorize?client_id=xxx&redirect_uri=https://mocktarget.apigee.net/echo&response_type=code&state=12345&scope=openid%20email
         Then response code should be 401
-    
+
     Scenario: I should get an error if response_type is missing or wrong
         Given I navigate to the authorize page with an invalid response type
         Then I am redirected to the Client App
@@ -29,7 +29,7 @@ Feature:
         Given I navigate to the authorize page without a scope parameter
         Then I am redirected to the Client App
         Then I receive an invalid_request error
-    
+
     Scenario: I should get an error if state is missing
         Given I navigate to the authorize page without a state parameter
         Then I am redirected to the Client App

--- a/references/oidc-mock/test/integration/features/oidc-mock.end-to-end.feature
+++ b/references/oidc-mock/test/integration/features/oidc-mock.end-to-end.feature
@@ -1,6 +1,6 @@
 @End-to-EndTests
 Feature:
-  As a Client App 
+  As a Client App
   I want to get an access token from an identity provider
   So that I can retrieve different types of information
 
@@ -14,11 +14,11 @@ Feature:
 
   Scenario: Generate Access Token
     Given I have basic authentication credentials `clientId` and `clientSecret`
-    And I set form parameters to 
+    And I set form parameters to
       | parameter   | value 			|
       | grant_type  | authorization_code 	|
       | code        | `authCode`              	|
-      | redirect_uri| https://httpbin.org/get 	|
+      | redirect_uri| https://mocktarget.apigee.net/echo 	|
       |	state	      | `state`			|
       | scope	      | openid email address    |
     When I POST to /token
@@ -31,7 +31,7 @@ Feature:
     Then response code should be 200
     And response body path $.email should be (.+@example.com)
 
-  Scenario: Client App Accesses Introspection Endpoint 
+  Scenario: Client App Accesses Introspection Endpoint
     Given I have basic authentication credentials `clientId` and `clientSecret`
     And I set form parameters to
       | parameter   | value	  |

--- a/references/oidc-mock/test/integration/features/oidc-mock.token.feature
+++ b/references/oidc-mock/test/integration/features/oidc-mock.token.feature
@@ -1,16 +1,16 @@
 @TokenIssuance
 Feature:
-    As a Client App 
+    As a Client App
     I want to get an access_token and id_token from an identity provider
     So that I can retrieve different types of information
 
     Scenario: Generate Access Token
         Given I have basic authentication credentials `clientId` and `clientSecret`
-        And I set form parameters to 
+        And I set form parameters to
         | parameter   | value		            |
         | grant_type  | authorization_code      |
         | code        | dummy-code-xyz          |
-        | redirect_uri| https://httpbin.org/get |
+        | redirect_uri| https://mocktarget.apigee.net/echo |
         |	state	  | `state`		            |
         | scope	      | openid email address    |
         When I POST to /token
@@ -20,11 +20,11 @@ Feature:
 
     Scenario: I should get an error if client_id and/or secret are wrong
         Given I have basic authentication credentials xxx and yyy
-        And I set form parameters to 
+        And I set form parameters to
         | parameter   | value		            |
         | grant_type  | authorization_code      |
         | code        | dummy-code-xyz          |
-        | redirect_uri| https://httpbin.org/get |
+        | redirect_uri| https://mocktarget.apigee.net/echo |
         | state       | `state` 	            |
         | scope	      | openid email address    |
         When I POST to /token
@@ -33,7 +33,7 @@ Feature:
 
     Scenario: I should get an error if redirect_uri is missing
         Given I have basic authentication credentials `clientId` and `clientSecret`
-        And I set form parameters to 
+        And I set form parameters to
         | parameter   | value		            |
         | grant_type  | authorization_code      |
         | code        | dummy-code-xyz          |
@@ -45,11 +45,11 @@ Feature:
 
     Scenario: I should get an error if grant_type is not authorization_code
         Given I have basic authentication credentials `clientId` and `clientSecret`
-        And I set form parameters to 
+        And I set form parameters to
         | parameter   | value		            |
         | grant_type  | xxx                     |
         | code        | dummy-code-xyz          |
-        | redirect_uri| https://httpbin.org/get |
+        | redirect_uri| https://mocktarget.apigee.net/echo |
         | state       | `state`		            |
         | scope	      | openid email address    |
         When I POST to /token
@@ -58,23 +58,23 @@ Feature:
 
     Scenario: I should get an error if code is not posted
         Given I have basic authentication credentials `clientId` and `clientSecret`
-        And I set form parameters to 
+        And I set form parameters to
         | parameter   | value		            |
         | grant_type  | authorization_code      |
-        | redirect_uri| https://httpbin.org/get |
+        | redirect_uri| https://mocktarget.apigee.net/echo |
         | state       | `state`		            |
         | scope	      | openid email address    |
         When I POST to /token
         Then response code should be 400
         And response body path $.error should be invalid_grant
-    
+
     Scenario: I should get an error if scope is not posted
         Given I have basic authentication credentials `clientId` and `clientSecret`
-        And I set form parameters to 
+        And I set form parameters to
         | parameter   | value		            |
         | grant_type  | authorization_code      |
         | code        | dummy-code-xyz          |
-        | redirect_uri| https://httpbin.org/get |
+        | redirect_uri| https://mocktarget.apigee.net/echo |
         | state       | `state`		            |
         When I POST to /token
         Then response code should be 400

--- a/references/oidc-mock/test/integration/features/step_definitions/ui.js
+++ b/references/oidc-mock/test/integration/features/step_definitions/ui.js
@@ -35,7 +35,7 @@ Given('I navigate to the authorize page', async function() {
   })
   this.page = await this.browser.newPage()
   return await this.page.goto('https://' + hostname + '/v1/openid-connect/authorize?client_id=' + this.apickli.scenarioVariables.clientId
-    + '&redirect_uri=https://httpbin.org/get&response_type=code&state=' + state +'&scope=' + scope)
+    + '&redirect_uri=https://mocktarget.apigee.net/echo&response_type=code&state=' + state +'&scope=' + scope)
 })
 
 Given('I navigate to the authorize page with an invalid response type', async function() {
@@ -46,7 +46,7 @@ Given('I navigate to the authorize page with an invalid response type', async fu
   })
   this.page = await this.browser.newPage()
   return await this.page.goto('https://' + hostname + '/v1/openid-connect/authorize?client_id=' + this.apickli.scenarioVariables.clientId
-    + '&redirect_uri=https://httpbin.org/get&response_type=xxx&state=' + state +'&scope=' + scope)
+    + '&redirect_uri=https://mocktarget.apigee.net/echo&response_type=xxx&state=' + state +'&scope=' + scope)
 })
 
 Given('I navigate to the authorize page without a scope parameter', async function() {
@@ -57,7 +57,7 @@ Given('I navigate to the authorize page without a scope parameter', async functi
   })
   this.page = await this.browser.newPage()
   return await this.page.goto('https://' + hostname + '/v1/openid-connect/authorize?client_id=' + this.apickli.scenarioVariables.clientId
-    + '&redirect_uri=https://httpbin.org/get&response_type=code&state=' + state)
+    + '&redirect_uri=https://mocktarget.apigee.net/echo&response_type=code&state=' + state)
 })
 
 Given('I navigate to the authorize page without a state parameter', async function() {
@@ -68,7 +68,7 @@ Given('I navigate to the authorize page without a state parameter', async functi
   })
   this.page = await this.browser.newPage()
   return await this.page.goto('https://' + hostname + '/v1/openid-connect/authorize?client_id=' + this.apickli.scenarioVariables.clientId
-    + '&redirect_uri=https://httpbin.org/get&response_type=code&&scope=' + scope)
+    + '&redirect_uri=https://mocktarget.apigee.net/echo&response_type=code&&scope=' + scope)
 })
 
 When('I sign in and consent', async function() {
@@ -93,7 +93,7 @@ When('I sign in and consent', async function() {
 })
 
 Then('I am redirected to the Client App', function() {
-  assert.notStrictEqual(this.page.url().indexOf('https://httpbin.org/get'), -1);
+  assert.notStrictEqual(this.page.url().indexOf('https://mocktarget.apigee.net/echo'), -1);
 })
 
 Then('I receive an auth code in a query param',  function() {

--- a/references/proxy-template/README.md
+++ b/references/proxy-template/README.md
@@ -22,7 +22,7 @@ It also has the following features:
 port, ssl enabled or not) are based on the environment variable `TARGET_URL`
   - The path that is set in `TARGET_URL` is used to configure a conditional flow
 on the proxy template. This flow is used to test the TargetServer
-  - The default value of `TARGET_URL` is `https://httpbin.org/headers`
+  - The default value of `TARGET_URL` is `https://mocktarget.apigee.net/echo`
 
 ## Dependencies
 

--- a/references/proxy-template/pipeline.sh
+++ b/references/proxy-template/pipeline.sh
@@ -22,7 +22,7 @@ PROXY=example
 VERSION=v1
 
 # default target server URL
-DEFAULT_TARGET_URL=https://httpbin.org/headers
+DEFAULT_TARGET_URL=https://mocktarget.apigee.net/echo
 
 # default Virtual Host
 VHOST=secure

--- a/references/recaptcha-enterprise/README.md
+++ b/references/recaptcha-enterprise/README.md
@@ -139,7 +139,7 @@ following artifacts:
 
 - ```recaptcha-data-proxy-v1```: a data proxy, which calls the reCAPTCHA
 enterprise sharedflow.
-The target endpoint of this proxy is [httpbin.org](https://httpbin.org)
+The target endpoint of this proxy is [mocktarget.apigee.net/echo](https://mocktarget.apigee.net/echo)
 - ```recaptcha-deliver-token-v1```: an API proxy used to deliver an HTML page that
 includes a valid reCAPTCHA
 token (cf. [Option 2](#option-2-recaptcha-enterprise-is-used)

--- a/references/recaptcha-enterprise/recaptcha-data-proxy-v1/apiproxy/targets/default.xml
+++ b/references/recaptcha-enterprise/recaptcha-data-proxy-v1/apiproxy/targets/default.xml
@@ -16,6 +16,6 @@
     <Flows/>
     <PostFlow name="PostFlow"/>
     <HTTPTargetConnection>
-        <URL>https://httpbin.org</URL>
+        <URL>https://mocktarget.apigee.net/echo</URL>
     </HTTPTargetConnection>
 </TargetEndpoint>

--- a/tools/apigee-envoy-quickstart/extension/README.md
+++ b/tools/apigee-envoy-quickstart/extension/README.md
@@ -1,10 +1,10 @@
 # Apigee Envoy extension (for external access)
 
-This is an extension to the starter setup of apigee-envoy deployment within GKE container platform with Apigee X/Hybrid as API management platform. 
+This is an extension to the starter setup of apigee-envoy deployment within GKE container platform with Apigee X/Hybrid as API management platform.
 
 The [starter kit](https://github.com/apigee/devrel/tree/main/tools/apigee-envoy-quickstart#envoy-with-apigee-adapter-as-containers-within-kubernetes-platform) deploys httpbin service configured with Envoy proxies as side car proxies. The Envoy proxy is enabled with apigee-adapter as step in the request path enforcing  Apigee provided authentication methods.
 
-This extension enables the exposure of deployed sample application (httpbin) externally via istio-ingressgateway. It showcases Apigee enabled envoy proxies can offer protection of API traffic intiated outside the mesh. 
+This extension enables the exposure of deployed sample application (httpbin) externally via istio-ingressgateway. It showcases Apigee enabled envoy proxies can offer protection of API traffic intiated outside the mesh.
 
 ![poc-setup](../assets/istio-apigee-envoy-external.png)
 
@@ -16,13 +16,13 @@ This extension enables the exposure of deployed sample application (httpbin) ext
 
 ### Pre-requisities:
 
-1. Deployment of [quickstart setup](https://github.com/apigee/devrel/tree/main/tools/apigee-envoy-quickstart#envoy-with-apigee-adapter-as-containers-within-kubernetes-platform) of apigee-envoy adapter within Istio enabled Kubernetes platform. 
+1. Deployment of [quickstart setup](https://github.com/apigee/devrel/tree/main/tools/apigee-envoy-quickstart#envoy-with-apigee-adapter-as-containers-within-kubernetes-platform) of apigee-envoy adapter within Istio enabled Kubernetes platform.
 
 1. Ensure Kubernetes cluster is running with istio-ingressgateway and supports external load balancers.(Execute [step 4 and 5](#set-the-namespace-hosting-istio-ingressgateway) below to setup ingressgateway, if missing within the cluster)
 
 ### Installation:
 
-1. **Set environment variables.** 
+1. **Set environment variables.**
     ```bash
     export USE_GKE_GCLOUD_AUTH_PLUGIN=True
     export GKE_PROJECT_ID=<gcp-project-id-hosting-the-cluster>
@@ -49,7 +49,7 @@ This extension enables the exposure of deployed sample application (httpbin) ext
 1. ### Set the namespace hosting istio-ingressgateway
     ```bash
     export ISTIO_GATEWAY_NS=<namespace-hosting-ingressgateway>
-    ```  
+    ```
 
 1. ### Execute the below if istio-ingressgateway is missing in the istio enabled cluster
     ```bash
@@ -70,8 +70,8 @@ This extension enables the exposure of deployed sample application (httpbin) ext
 
 1. **Overwrite the service details that has to be exposed outside the mesh, if different from the service (httpbin application) deployed in the [starter kit](https://github.com/apigee/devrel/tree/main/tools/apigee-envoy-quickstart#envoy-with-apigee-adapter-as-containers-within-kubernetes-platform)**
     ```bash
-    export TARGET_HOST="httpbin.org"
-    export TARGET_SERVICE_NAME="httpbin"
+    export TARGET_HOST="mocktarget.apigee.net"
+    export TARGET_SERVICE_NAME="mocktarget"
     export TARGET_SERVICE_NAMESPACE="apigee"
     ```
 
@@ -139,10 +139,10 @@ This extension enables the exposure of deployed sample application (httpbin) ext
     -H "Content-Type:application/json" \
     "https://apigee.googleapis.com/v1/organizations/${APIGEE_ORG}/developers/test-envoy@google.com/apps/envoy-adapter-dev-app" | \
     jq '.credentials[0].consumerKey'); \
-    CONSUMER_KEY=$(echo "$CONSUMER_KEY"|cut -d '"' -f 2); 
+    CONSUMER_KEY=$(echo "$CONSUMER_KEY"|cut -d '"' -f 2);
     ```
 
 1. **Testing protected service via external IP...**
     ```bash
-    curl -i http://"$INGRESS_HOST"/httpbin/headers -H "x-api-key: $CONSUMER_KEY"
+    curl -i http://"$INGRESS_HOST"/httpbin/echo -H "x-api-key: $CONSUMER_KEY"
     ```

--- a/tools/apigee-envoy-quickstart/scripts/setup-apigee.sh
+++ b/tools/apigee-envoy-quickstart/scripts/setup-apigee.sh
@@ -30,7 +30,7 @@ then
         "value" : "public"
     }, {
         "name" : "apigee-remote-service-targets",
-        "value" : "httpbin.org"
+        "value" : "mocktarget.apigee.net"
     } ],
     "description" : "API Product for api proxies in Envoy",
     "environments": [
@@ -66,7 +66,7 @@ else
             "quota": {}
         },
         {
-            "apiSource": "httpbin.org",
+            "apiSource": "mocktarget.apigee.net",
             "operations": [
             {
                 "resource": "/headers"

--- a/tools/apigee-envoy-quickstart/scripts/test-standalone-apigee-envoy-filter.sh
+++ b/tools/apigee-envoy-quickstart/scripts/test-standalone-apigee-envoy-filter.sh
@@ -14,10 +14,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-testHttpbin() {
+testMocktarget() {
     printf "\nTesting deployed envoy proxy with apigee adapter\n"
     RESULT=1
-    OUTPUT=$(curl -i http://localhost:8080/headers -H 'Host: httpbin.org' \
+    OUTPUT=$(curl -i http://localhost:8080/echo -H 'Host: mocktarget.apigee.net' \
         -H "x-api-key: $CONSUMER_KEY" | grep HTTP)
     printf "\n%s" "$OUTPUT"
     if [[ "$OUTPUT" == *"200"* ]]; then
@@ -26,13 +26,13 @@ testHttpbin() {
     return $RESULT
 }
 
-testCIRunnerHttpbin() {
+testCIRunnerMocktarget() {
     printf "\nTesting deployed envoy proxy with apigee adapter for CI runner build\n"
     envoyproxy_cntnr_name=$(docker ps -a --format "{{ json . }}" | \
                             jq ' select( .Image | contains("envoyproxy")) | .Names ' | \
                             tr -d '"')
     RESULT=1
-    OUTPUT=$(docker exec -it "$envoyproxy_cntnr_name" curl -i http://localhost:8080/headers -H 'Host: httpbin.org' \
+    OUTPUT=$(docker exec -it "$envoyproxy_cntnr_name" curl -i http://localhost:8080/echo -H 'Host: mocktarget.apigee.net' \
         -H "x-api-key: $CONSUMER_KEY" | grep HTTP)
     printf "\n%s" "$OUTPUT"
     if [[ "$OUTPUT" == *"200"* ]]; then
@@ -53,12 +53,12 @@ printf "\nWait for few minutes for the Envoy and Apigee adapter to have the setu
 
 printf "\n\n"
 
-echo curl -i http://localhost:8080/headers -H "\"Host: httpbin.org\""  \
+echo curl -i http://localhost:8080/echo -H "\"Host: mocktarget.apigee.net\""  \
 -H "\"x-api-key: $CONSUMER_KEY\""
 
 printf "\n"
 
-printf "\nTry with and without sending the x-api-key header. This proves the httpbin target is protected by the Envoy container which has the Envoy filter configured to connect to Apigee adapter running as container that executes the key verification with the Apigee runtime\n"
+printf "\nTry with and without sending the x-api-key header. This proves the mock target is protected by the Envoy container which has the Envoy filter configured to connect to Apigee adapter running as container that executes the key verification with the Apigee runtime\n"
 
 
 printf "\nWaiting for envoy proxy to be ready.."
@@ -66,28 +66,28 @@ sleep 20
 printf "\nTesting envoy endpoint.."
 
 if [[ -z $PIPELINE_TEST ]]; then
-  testHttpbin;
+  testMocktarget;
 else
-  testCIRunnerHttpbin
+  testCIRunnerMocktarget
 fi
 RESULT=$?
 
 counter=0;
 while [ $RESULT -ne 0 ] && [ $counter -lt 5 ]; do
-  printf "\n\nTesting the httpbin application %s of 5\n" "$counter"
+  printf "\n\nTesting the mocktarget application %s of 5\n" "$counter"
   sleep 20
   if [[ -z $PIPELINE_TEST ]]; then
-    testHttpbin;
+    testMocktarget;
   else
-    testCIRunnerHttpbin
+    testCIRunnerMocktarget
   fi
   RESULT=$?
   counter=$((counter+1))
 done
 
 if [ $RESULT -eq 0 ]; then
-  printf "\nValidation of the apigee envoy quickstart engine successful\n" 
+  printf "\nValidation of the apigee envoy quickstart engine successful\n"
 else
-  printf "\nValidation of the apigee envoy quickstart engine NOT successful\n" 
+  printf "\nValidation of the apigee envoy quickstart engine NOT successful\n"
 fi
 

--- a/tools/endpoints-oas-importer/examples/openapi_test.json
+++ b/tools/endpoints-oas-importer/examples/openapi_test.json
@@ -24,7 +24,7 @@
           }
         },
         "x-google-backend": {
-          "address": "https://httpbin.org",
+          "address": "https://mocktarget.apigee.net/echo",
           "deadline": 7,
           "disable_auth": true,
           "path_translation": "APPEND_PATH_TO_ADDRESS",

--- a/tools/endpoints-oas-importer/examples/openapi_test.yaml
+++ b/tools/endpoints-oas-importer/examples/openapi_test.yaml
@@ -23,7 +23,7 @@ schemes:
   - "https"
 x-google-allow: all
 x-google-backend:
-  address: https://httpbin.org/anything
+  address: https://mocktarget.apigee.net/echo
   protocol: h2
   disable_auth: true
 paths:
@@ -35,7 +35,7 @@ paths:
         '200':
           description: Request Headers.
       x-google-backend:
-        address: https://httpbin.org
+        address: https://mocktarget.apigee.net/echo
         path_translation: APPEND_PATH_TO_ADDRESS
         disable_auth: true
   "/headers/{headerId}/bar":


### PR DESCRIPTION
## Description
What's changed, or what was fixed?

- replace httpbin for mocktarget to improve test stability 
- Currently out of scope and still rely on httpbin.org 
  - OIDC Mocktarget / Identityfacade / Lab Okta integration (This requires query param support on the mock backend) 
  - Envoy Quickstart (Some analysis required)
  
## Issues Fixed
- Fixes Nightly build failures

## Housekeeping
(please check all that apply [x], do not edit the text)
- [ ] I have run all the tests locally and they all pass.
- [ ] I have followed the relevant style guide for my changes.

## Full Repo Validation Required
(please check all that apply [x], do not edit the text)
- [ ] PR requires full pipeline run (Run for changes only by default).

**CC:** @apigee-devrel-reviewers
