### PR TITLE
fix: only try to delete untagged images

### DIFF
--- a/tools/pipeline-runner/image-clean.cloudbuild.yaml
+++ b/tools/pipeline-runner/image-clean.cloudbuild.yaml
@@ -25,7 +25,7 @@ steps:
           echo "Cleaning stale versions of: $$IMAGE_URI"
           VERSIONS_TO_CLEAN=$(gcloud artifacts docker images list "$$IMAGE_URI" \
             --include-tags \
-            --filter="UPDATE_TIME.date('%Y-%m-%d', Z)<=$(date --date="-${_IMAGE_RETENTION_MIN} days" +'%Y-%m-%d')" \
+            --filter="UPDATE_TIME.date('%Y-%m-%d', Z)<=$(date --date="-${_IMAGE_RETENTION_MIN} days" +'%Y-%m-%d') AND -TAGS:*" \
             --format='value(VERSION)')
 
           if [ -z "$$VERSIONS_TO_CLEAN" ]; then


### PR DESCRIPTION
## Description
What's changed, or what was fixed?

- Nightly image clean up tries to delete tagged images which isn't allowed.

## Issues Fixed
- Fixes #

## Housekeeping
(please check all that apply [x], do not edit the text)
- [ ] I have run all the tests locally and they all pass.
- [ ] I have followed the relevant style guide for my changes.

## Full Repo Validation Required
(please check all that apply [x], do not edit the text)
- [ ] PR requires full pipeline run (Run for changes only by default).

**CC:** @apigee-devrel-reviewers
